### PR TITLE
Add standard lint tools to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,17 @@ default: moby
 DEPS=$(wildcard cmd/moby/*.go) Makefile
 PREFIX?=/usr/local
 
-moby: $(DEPS)
+moby: $(DEPS) lint
 	go build --ldflags "-X main.GitCommit=$(GIT_COMMIT) -X main.Version=$(VERSION)" -o $@ github.com/moby/tool/cmd/moby
+
+lint:
+	@echo "+ $@: golint, gofmt, go vet"
+	# golint
+	@test -z "$(shell find . -type f -name "*.go" -not -path "./vendor/*" -not -name "*.pb.*" -exec golint {} \; | tee /dev/stderr)"
+	# gofmt
+	@test -z "$$(gofmt -s -l .| grep -v .pb. | grep -v vendor/ | tee /dev/stderr)"
+	# govet
+	@test -z "$$(go tool vet -printf=false . 2>&1 | grep -v vendor/ | tee /dev/stderr)"
 
 PHONY: install
 install: moby


### PR DESCRIPTION
`gofmt`, `golint`, `go vet` - can add more like `ineffassign` as well but those would require `go get` and probably would make us want to use the linuxkit `go-compile`.  Figured it would be best to keep this separate.

Taken from notary.

Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>

<img src="http://media.indiatimes.in/media/content/2015/Nov/weaselpecker_3411093k_1447323311.jpg" width="400" />