### PR TITLE
Don't exit after pulling init or kernel image without -pull

### DIFF
--- a/cmd/moby/image.go
+++ b/cmd/moby/image.go
@@ -114,9 +114,9 @@ func imageTar(image, prefix string, tw *tar.Writer, trust bool, pull bool) error
 			if err != nil {
 				return fmt.Errorf("Failed to docker create image %s: %v", image, err)
 			}
+		} else {
+			return fmt.Errorf("Failed to create docker image %s: %v", image, err)
 		}
-		return fmt.Errorf("Failed to create docker image %s: %v", image, err)
-
 	}
 	contents, err := dockerExport(container)
 	if err != nil {


### PR DESCRIPTION
Due to a missing else the tool would previously terminate with an error
message showing that the kernel or init image didn't exist, even if it
was pulled successfully. Invoking the tool again would continue to the
next image.

Signed-off-by: Magnus Skjegstad <magnus@skjegstad.com>