### PR TITLE
Fix symlinks handling in initramfs

### DIFF
--- a/cmd/moby/build.go
+++ b/cmd/moby/build.go
@@ -136,25 +136,27 @@ func buildInternal(m *Moby, name string, pull bool) []byte {
 			log.Fatalf("Could not pull image %s: %v", m.Kernel.Image, err)
 		}
 	}
-	// get kernel and initrd tarball from container
-	log.Infof("Extract kernel image: %s", m.Kernel.Image)
-	const (
-		kernelName    = "kernel"
-		kernelAltName = "bzImage"
-		ktarName      = "kernel.tar"
-	)
-	out, err := ImageExtract(m.Kernel.Image, "", enforceContentTrust(m.Kernel.Image, &m.Trust), pull)
-	if err != nil {
-		log.Fatalf("Failed to extract kernel image and tarball: %v", err)
-	}
-	buf := bytes.NewBuffer(out)
+	if m.Kernel.Image != "" {
+		// get kernel and initrd tarball from container
+		log.Infof("Extract kernel image: %s", m.Kernel.Image)
+		const (
+			kernelName    = "kernel"
+			kernelAltName = "bzImage"
+			ktarName      = "kernel.tar"
+		)
+		out, err := ImageExtract(m.Kernel.Image, "", enforceContentTrust(m.Kernel.Image, &m.Trust), pull)
+		if err != nil {
+			log.Fatalf("Failed to extract kernel image and tarball: %v", err)
+		}
+		buf := bytes.NewBuffer(out)
 
-	kernel, ktar, err := untarKernel(buf, kernelName, kernelAltName, ktarName, m.Kernel.Cmdline)
-	if err != nil {
-		log.Fatalf("Could not extract kernel image and filesystem from tarball. %v", err)
+		kernel, ktar, err := untarKernel(buf, kernelName, kernelAltName, ktarName, m.Kernel.Cmdline)
+		if err != nil {
+			log.Fatalf("Could not extract kernel image and filesystem from tarball. %v", err)
+		}
+		initrdAppend(iw, kernel)
+		initrdAppend(iw, ktar)
 	}
-	initrdAppend(iw, kernel)
-	initrdAppend(iw, ktar)
 
 	// convert init images to tarballs
 	log.Infof("Add init containers:")

--- a/cmd/moby/build.go
+++ b/cmd/moby/build.go
@@ -159,7 +159,9 @@ func buildInternal(m *Moby, name string, pull bool) []byte {
 	}
 
 	// convert init images to tarballs
-	log.Infof("Add init containers:")
+	if len(m.Init) != 0 {
+		log.Infof("Add init containers:")
+	}
 	for _, ii := range m.Init {
 		log.Infof("Process init image: %s", ii)
 		init, err := ImageExtract(ii, "", enforceContentTrust(ii, &m.Trust), pull)
@@ -170,7 +172,9 @@ func buildInternal(m *Moby, name string, pull bool) []byte {
 		initrdAppend(iw, buffer)
 	}
 
-	log.Infof("Add onboot containers:")
+	if len(m.Onboot) != 0 {
+		log.Infof("Add onboot containers:")
+	}
 	for i, image := range m.Onboot {
 		log.Infof("  Create OCI config for %s", image.Image)
 		config, err := ConfigToOCI(&image)
@@ -187,7 +191,9 @@ func buildInternal(m *Moby, name string, pull bool) []byte {
 		initrdAppend(iw, buffer)
 	}
 
-	log.Infof("Add service containers:")
+	if len(m.Services) != 0 {
+		log.Infof("Add service containers:")
+	}
 	for _, image := range m.Services {
 		log.Infof("  Create OCI config for %s", image.Image)
 		config, err := ConfigToOCI(&image)

--- a/cmd/moby/config.go
+++ b/cmd/moby/config.go
@@ -32,6 +32,7 @@ type Moby struct {
 	Files    []struct {
 		Path      string
 		Directory bool
+		Symlink   string
 		Contents  string
 	}
 	Outputs []struct {
@@ -438,7 +439,7 @@ func filesystem(m *Moby) (*bytes.Buffer, error) {
 		if f.Path == "" {
 			return buf, errors.New("Did not specify path for file")
 		}
-		if !f.Directory && f.Contents == "" {
+		if !f.Directory && f.Contents == "" && f.Symlink == "" {
 			return buf, errors.New("Contents of file not specified")
 		}
 		// we need all the leading directories
@@ -472,6 +473,17 @@ func filesystem(m *Moby) (*bytes.Buffer, error) {
 				Name:     f.Path,
 				Typeflag: tar.TypeDir,
 				Mode:     0700,
+			}
+			err := tw.WriteHeader(hdr)
+			if err != nil {
+				return buf, err
+			}
+		} else if f.Symlink != "" {
+			hdr := &tar.Header{
+				Name:     f.Path,
+				Typeflag: tar.TypeSymlink,
+				Mode:     0600,
+				Linkname: f.Symlink,
 			}
 			err := tw.WriteHeader(hdr)
 			if err != nil {

--- a/cmd/moby/config.go
+++ b/cmd/moby/config.go
@@ -430,7 +430,9 @@ func filesystem(m *Moby) (*bytes.Buffer, error) {
 	tw := tar.NewWriter(buf)
 	defer tw.Close()
 
-	log.Infof("Add files:")
+	if len(m.Files) != 0 {
+		log.Infof("Add files:")
+	}
 	for _, f := range m.Files {
 		log.Infof("  %s", f.Path)
 		if f.Path == "" {

--- a/cmd/moby/output.go
+++ b/cmd/moby/output.go
@@ -111,6 +111,7 @@ func tarToInitrd(image []byte) ([]byte, []byte, string, error) {
 	if err != nil {
 		return []byte{}, []byte{}, "", err
 	}
+	iw.Close()
 	return kernel, w.Bytes(), cmdline, nil
 }
 

--- a/cmd/moby/schema.go
+++ b/cmd/moby/schema.go
@@ -20,6 +20,7 @@ var schema = string(`
         "properties": {
           "path": {"type": "string"},
           "directory": {"type": "boolean"},
+          "symlink": {"type": "string"},
           "contents": {"type": "string"}
         }
     },

--- a/vendor.conf
+++ b/vendor.conf
@@ -4,7 +4,7 @@ github.com/docker/docker 420b67f892d5424be59a788a51e2c4e64bb9cd66
 github.com/docker/go-connections e15c02316c12de00874640cd76311849de2aeed5
 github.com/docker/go-units 651fc226e7441360384da338d0fd37f2440ffbe3
 github.com/docker/libtrust 9cbd2a1374f46905c68a4eb3694a130610adc62a
-github.com/linuxkit/linuxkit 17dd50cec61de35c48b786998a154678dc46ff6a
+github.com/linuxkit/linuxkit ad8a4cad1f45a08f7dbc0ab02f28be31f767f1fd
 github.com/opencontainers/go-digest a6d0ee40d4207ea02364bd3b9e8e77b9159ba1eb
 github.com/opencontainers/runtime-spec d094a5c9c1997ab086197b57e9378fabed394d92
 github.com/pkg/errors ff09b135c25aae272398c51a07235b90a75aa4f0


### PR DESCRIPTION
In order to test this better, added support for symlinks in `files` section and made the output quieter if you dont use sections.

See https://github.com/linuxkit/linuxkit/issues/1792