### PR TITLE
add Source attribute to File

### DIFF
--- a/cmd/moby/config.go
+++ b/cmd/moby/config.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -34,6 +35,7 @@ type Moby struct {
 		Directory bool
 		Symlink   string
 		Contents  string
+		Source    string
 	}
 	Outputs []struct {
 		Format string
@@ -440,7 +442,16 @@ func filesystem(m *Moby) (*bytes.Buffer, error) {
 			return buf, errors.New("Did not specify path for file")
 		}
 		if !f.Directory && f.Contents == "" && f.Symlink == "" {
-			return buf, errors.New("Contents of file not specified")
+			if f.Source == "" {
+				return buf, errors.New("Contents of file not specified")
+			}
+
+			contents, err := ioutil.ReadFile(f.Source)
+			if err != nil {
+				return buf, err
+			}
+
+			f.Contents = string(contents)
 		}
 		// we need all the leading directories
 		parts := strings.Split(path.Dir(f.Path), "/")

--- a/cmd/moby/schema.go
+++ b/cmd/moby/schema.go
@@ -21,11 +21,12 @@ var schema = string(`
           "path": {"type": "string"},
           "directory": {"type": "boolean"},
           "symlink": {"type": "string"},
-          "contents": {"type": "string"}
+          "contents": {"type": "string"},
+          "source": {"type": "string"}
         }
     },
     "files": {
-        "type": "array", 
+        "type": "array",
         "items": { "$ref": "#/definitions/file" }
     },
     "output": {
@@ -36,7 +37,7 @@ var schema = string(`
       }
     },
     "outputs": {
-        "type": "array", 
+        "type": "array",
         "items": { "$ref": "#/definitions/output" }
     },
     "trust": {
@@ -48,7 +49,7 @@ var schema = string(`
       }
     },
     "strings": {
-        "type": "array", 
+        "type": "array",
         "items": {"type": "string"}
     },
     "mount": {
@@ -89,7 +90,7 @@ var schema = string(`
         "uid": {"type": "integer"},
         "gid": {"type": "integer"},
         "additionalGids": {
-            "type": "array", 
+            "type": "array",
             "items": { "type": "integer" }
         },
         "noNewPrivileges": {"type": "boolean"},
@@ -99,18 +100,18 @@ var schema = string(`
         "rootfsPropagation": {"type": "string"},
         "cgroupsPath": {"type": "string"},
         "sysctl": {
-            "type": "array", 
+            "type": "array",
             "items": { "$ref": "#/definitions/strings" }
         }
       }
     },
     "images": {
-        "type": "array", 
+        "type": "array",
         "items": { "$ref": "#/definitions/image" }
     }
   },
   "properties": {
-    "kernel": { "$ref": "#/definitions/kernel" },  
+    "kernel": { "$ref": "#/definitions/kernel" },
     "init": { "$ref": "#/definitions/strings" },
     "onboot": { "$ref": "#/definitions/images" },
     "services": { "$ref": "#/definitions/images" },


### PR DESCRIPTION
This PR proposes adding the `source` attribute to the `file` struct.

### Use Case
When preparing an image bundling `dockerd`, we usually embed the generated server certificate and key (`server.pem` and `server-key.pem`) to the image for fast deployment. This `source` attribute allows us to copy the content of these files into the image.  

Signed-off-by: Chanwit Kaewkasi <chanwit@gmail.com>

