### PR TITLE
Fix docker pull

### DIFF
--- a/cmd/moby/docker.go
+++ b/cmd/moby/docker.go
@@ -176,7 +176,13 @@ func dockerPull(image string, trustedPull bool) error {
 		return errors.New("could not initialize Docker API client")
 	}
 
-	if _, err := cli.ImagePull(context.Background(), image, types.ImagePullOptions{}); err != nil {
+	r, err := cli.ImagePull(context.Background(), image, types.ImagePullOptions{})
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+	_, err = io.Copy(ioutil.Discard, r)
+	if err != nil {
 		return err
 	}
 	log.Debugf("docker pull: %s...Done", image)

--- a/cmd/moby/image.go
+++ b/cmd/moby/image.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 
 	log "github.com/Sirupsen/logrus"
-	"github.com/docker/docker/client"
 )
 
 // This uses Docker to convert a Docker image into a tarball. It would be an improvement if we
@@ -104,7 +103,7 @@ func imageTar(image, prefix string, tw *tar.Writer, trust bool, pull bool) error
 	container, err := dockerCreate(image)
 	if err != nil {
 		// if the image wasn't found, pull it down.  Bail on other errors.
-		if client.IsErrNotFound(err) {
+		if strings.Contains(err.Error(), "No such image") {
 			log.Infof("Pull image: %s", image)
 			err := dockerPull(image, trust)
 			if err != nil {


### PR DESCRIPTION
Signed-off-by: Justin Cormack <justin.cormack@docker.com>

cc @riyaz this isnt very well documented but if you ignore the `io.Reader` returned by `ImagePull` the connection will be closed before the pull happens.

I answered the relevant Stack Overflow question... http://stackoverflow.com/questions/42816132/docker-run-using-golang-api-docker-docs/43937375#43937375