### PR TITLE
Simple test target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,10 @@ lint:
 	# govet
 	@test -z "$$(go tool vet -printf=false . 2>&1 | grep -v vendor/ | tee /dev/stderr)"
 
+test: moby
+	./moby build test/test.yml
+	rm moby test.iso test-cmdline test-efi.iso test-initrd.img test-kernel
+
 PHONY: install
 install: moby
 	cp -a $^ $(PREFIX)/bin/

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ lint:
 
 test: moby
 	./moby build test/test.yml
-	rm moby test.iso test-cmdline test-efi.iso test-initrd.img test-kernel
+	rm moby test.tar
 
 PHONY: install
 install: moby

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,3 @@
+test:
+  override:
+    - make test

--- a/test/test.yml
+++ b/test/test.yml
@@ -57,6 +57,4 @@ trust:
     - linuxkit/binfmt
     - linuxkit/rngd
 outputs:
-  - format: kernel+initrd
-  - format: iso-bios
-  - format: iso-efi
+  - format: tar

--- a/test/test.yml
+++ b/test/test.yml
@@ -1,0 +1,62 @@
+# linuxkit.yml from linuxkit/linuxkit 2388f483c397010d528a9a97b71224dbdb3897b5
+kernel:
+  image: "linuxkit/kernel:4.9.x"
+  cmdline: "console=ttyS0 console=tty0 page_poison=1"
+init:
+  - linuxkit/init:b3740303f3d1e5689a84c87b7dfb48fd2a40a192
+  - linuxkit/runc:2649198589ef0020d99f613adaeda45ce0093a38
+  - linuxkit/containerd:cf2614f5a96c569a0bd4bd54e054a65ba17d167f
+  - linuxkit/ca-certificates:3344cdca1bc59fdfa17bd7f0fcbf491b9dbaa288
+onboot:
+  - name: sysctl
+    image: "linuxkit/sysctl:2cf2f9d5b4d314ba1bfc22b2fe931924af666d8c"
+    net: host
+    pid: host
+    ipc: host
+    capabilities:
+     - CAP_SYS_ADMIN
+    readonly: true
+  - name: binfmt
+    image: "linuxkit/binfmt:131026c0cf6084467316395fed3b358f64bda00c"
+    binds:
+     - /proc/sys/fs/binfmt_misc:/binfmt_misc
+    readonly: true
+  - name: dhcpcd
+    image: "linuxkit/dhcpcd:2def74ab3f9233b4c09ebb196ba47c27c08b0ed8"
+    binds:
+     - /var:/var
+     - /tmp/etc:/etc
+    capabilities:
+     - CAP_NET_ADMIN
+     - CAP_NET_BIND_SERVICE
+     - CAP_NET_RAW
+    net: host
+    command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
+services:
+  - name: rngd
+    image: "linuxkit/rngd:61a07ced77a9747708223ca16a4aec621eacf518"
+    capabilities:
+     - CAP_SYS_ADMIN
+    oomScoreAdj: -800
+    readonly: true
+  - name: nginx
+    image: "nginx:alpine"
+    capabilities:
+     - CAP_NET_BIND_SERVICE
+     - CAP_CHOWN
+     - CAP_SETUID
+     - CAP_SETGID
+     - CAP_DAC_OVERRIDE
+    net: host
+files:
+  - path: etc/docker/daemon.json
+    contents: '{"debug": true}'
+trust:
+  image:
+    - linuxkit/kernel
+    - linuxkit/binfmt
+    - linuxkit/rngd
+outputs:
+  - format: kernel+initrd
+  - format: iso-bios
+  - format: iso-efi


### PR DESCRIPTION
This adds a very simple `make test` target that we can hook into a CI system like circle/travis/jenkins/(your favorite system here).

At present, the test does the following:
- runs golang linters
- compiles moby tool
- clones the linuxkit repo for a sample yml
- builds the sample `linuxkit.yml`

I've added a sample `circle.yml` file but because I am not an admin for this repo/org I can't hook it up/test it.

This test can (and should) be factored out into a more full-featured suite and include golang unit tests, but I wanted a quick smoke test that we could start enforcing against PRs in the short term to get this going.