### PR TITLE
Add support for override of parameters using a label

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ PREFIX?=/usr/local
 moby: $(DEPS) lint
 	go build --ldflags "-X main.GitCommit=$(GIT_COMMIT) -X main.Version=$(VERSION)" -o $@ github.com/moby/tool/cmd/moby
 
+.PHONY: lint
 lint:
 	@echo "+ $@: golint, gofmt, go vet"
 	# golint
@@ -17,6 +18,8 @@ lint:
 	@test -z "$$(gofmt -s -l .| grep -v .pb. | grep -v vendor/ | tee /dev/stderr)"
 	# govet
 	@test -z "$$(go tool vet -printf=false . 2>&1 | grep -v vendor/ | tee /dev/stderr)"
+	# go test
+	@go test github.com/moby/tool/cmd/moby
 
 test: moby
 	./moby build test/test.yml

--- a/cmd/moby/build.go
+++ b/cmd/moby/build.go
@@ -125,7 +125,7 @@ func enforceContentTrust(fullImageName string, config *TrustConfig) bool {
 
 // Perform the actual build process
 // TODO return error not panic
-func buildInternal(m *Moby, name string, pull bool) []byte {
+func buildInternal(m Moby, name string, pull bool) []byte {
 	w := new(bytes.Buffer)
 	iw := tar.NewWriter(w)
 
@@ -177,7 +177,7 @@ func buildInternal(m *Moby, name string, pull bool) []byte {
 	}
 	for i, image := range m.Onboot {
 		log.Infof("  Create OCI config for %s", image.Image)
-		config, err := ConfigToOCI(&image)
+		config, err := ConfigToOCI(image)
 		if err != nil {
 			log.Fatalf("Failed to create config.json for %s: %v", image.Image, err)
 		}
@@ -196,7 +196,7 @@ func buildInternal(m *Moby, name string, pull bool) []byte {
 	}
 	for _, image := range m.Services {
 		log.Infof("  Create OCI config for %s", image.Image)
-		config, err := ConfigToOCI(&image)
+		config, err := ConfigToOCI(image)
 		if err != nil {
 			log.Fatalf("Failed to create config.json for %s: %v", image.Image, err)
 		}

--- a/cmd/moby/config_test.go
+++ b/cmd/moby/config_test.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
+)
+
+func TestOverrides(t *testing.T) {
+	var yamlCaps = []string{"CAP_SYS_ADMIN"}
+
+	var yaml MobyImage = MobyImage{
+		Name:         "test",
+		Image:        "testimage",
+		Capabilities: &yamlCaps,
+	}
+
+	var labelCaps = []string{"CAP_SYS_CHROOT"}
+
+	var label MobyImage = MobyImage{
+		Capabilities: &labelCaps,
+		Cwd:          "/label/directory",
+	}
+
+	var inspect types.ImageInspect
+	var config container.Config
+
+	labelJSON, err := json.Marshal(label)
+	if err != nil {
+		t.Error(err)
+	}
+	config.Labels = map[string]string{"org.mobyproject.config": string(labelJSON)}
+
+	inspect.Config = &config
+
+	oci, err := ConfigInspectToOCI(yaml, inspect)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if !reflect.DeepEqual(oci.Process.Capabilities.Bounding, yamlCaps) {
+		t.Error("Expected yaml capabilities to override but got", oci.Process.Capabilities.Bounding)
+	}
+	if oci.Process.Cwd != label.Cwd {
+		t.Error("Expected label Cwd to be applied, got", oci.Process.Cwd)
+	}
+}

--- a/cmd/moby/output.go
+++ b/cmd/moby/output.go
@@ -21,7 +21,7 @@ const (
 	vmdk = "linuxkit/mkimage-vmdk:182b541474ca7965c8e8f987389b651859f760da@sha256:99638c5ddb17614f54c6b8e11bd9d49d1dea9d837f38e0f6c1a5f451085d449b"
 )
 
-func outputs(m *Moby, base string, image []byte) error {
+func outputs(m Moby, base string, image []byte) error {
 	log.Debugf("output: %s %s", m.Outputs, base)
 
 	for _, o := range m.Outputs {


### PR DESCRIPTION
Using the label `org.mobyproject.config` will use that JSON
(or yaml, but it is very hard to get yaml into a label as newlines are
not respected) for parameters that are not explicitly set in the yaml file.

Had to change parameter definitions so override behaves as expected.

fix #16

Signed-off-by: Justin Cormack <justin.cormack@docker.com>