### PR TITLE
Remove output formats from the Yaml file, put in CLI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ lint:
 	@go test github.com/moby/tool/cmd/moby
 
 test: moby
-	./moby build test/test.yml
+	./moby build -output tar test/test.yml
 	rm moby test.tar
 
 PHONY: install

--- a/cmd/moby/config.go
+++ b/cmd/moby/config.go
@@ -38,9 +38,6 @@ type Moby struct {
 		Contents  string
 		Source    string
 	}
-	Outputs []struct {
-		Format string
-	}
 }
 
 // TrustConfig is the type of a content trust config

--- a/cmd/moby/config_test.go
+++ b/cmd/moby/config_test.go
@@ -12,7 +12,7 @@ import (
 func TestOverrides(t *testing.T) {
 	var yamlCaps = []string{"CAP_SYS_ADMIN"}
 
-	var yaml MobyImage = MobyImage{
+	var yaml = MobyImage{
 		Name:         "test",
 		Image:        "testimage",
 		Capabilities: &yamlCaps,
@@ -20,7 +20,7 @@ func TestOverrides(t *testing.T) {
 
 	var labelCaps = []string{"CAP_SYS_CHROOT"}
 
-	var label MobyImage = MobyImage{
+	var label = MobyImage{
 		Capabilities: &labelCaps,
 		Cwd:          "/label/directory",
 	}

--- a/cmd/moby/schema.go
+++ b/cmd/moby/schema.go
@@ -29,17 +29,6 @@ var schema = string(`
         "type": "array",
         "items": { "$ref": "#/definitions/file" }
     },
-    "output": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "format": {"type": "string"}
-      }
-    },
-    "outputs": {
-        "type": "array",
-        "items": { "$ref": "#/definitions/output" }
-    },
     "trust": {
       "type": "object",
       "additionalProperties": false,
@@ -116,8 +105,7 @@ var schema = string(`
     "onboot": { "$ref": "#/definitions/images" },
     "services": { "$ref": "#/definitions/images" },
     "trust": { "$ref": "#/definitions/trust" },
-    "files": { "$ref": "#/definitions/files" },
-    "outputs": { "$ref": "#/definitions/outputs" }
+    "files": { "$ref": "#/definitions/files" }
   }
 }
 `)

--- a/test/test.yml
+++ b/test/test.yml
@@ -56,5 +56,3 @@ trust:
     - linuxkit/kernel
     - linuxkit/binfmt
     - linuxkit/rngd
-outputs:
-  - format: tar


### PR DESCRIPTION
This removes outputs from yaml, instead you can do
```
moby build -output tar -output qcow2 file.yaml
```
or alternative syntax
```
moby build -output tar,qcow2 file.yaml
```

In future we may change this to be available in a `moby package`
step, but lets try this for now.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>