### PR TITLE
Fix gitignore to not ignore moby directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-moby
+/moby


### PR DESCRIPTION
Signed-off-by: Justin Cormack <justin.cormack@docker.com>