### PR TITLE
trust: use a tempdir and remove after build

### DIFF
--- a/cmd/moby/trust.go
+++ b/cmd/moby/trust.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
 	"time"
 
@@ -61,8 +62,14 @@ func TrustedReference(image string) (reference.Reference, error) {
 		return nil, err
 	}
 
+	tmpTrustDir, err := ioutil.TempDir("", "notary")
+	if err != nil {
+		return nil, err
+	}
+	defer os.Remove(tmpTrustDir)
+
 	nRepo, err := notaryClient.NewNotaryRepository(
-		"",
+		tmpTrustDir,
 		gun,
 		server,
 		rt,


### PR DESCRIPTION
This dir is where you'd place private keys for signing but this is irrelevant for build.  Also where the moby tool pulls down metadata from the server, but this can be removed - we could cache it in a canonical moby tool directory like docker (`~/.docker`) and notary (`~/.notary`) do, if we'd like to in the future.

<img src="https://scopicimpulse.files.wordpress.com/2017/05/comedy-wildlife-photography-awards-shortlist-2016-21-57fb40bf1e29b__880.jpg" width="400"></img>

Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>