### PR TITLE
Always include rbind in user-specified volume options

### DIFF
--- a/cmd/moby/config.go
+++ b/cmd/moby/config.go
@@ -477,7 +477,7 @@ func ConfigInspectToOCI(yaml MobyImage, inspect types.ImageInspect) (specs.Spec,
 		dest := parts[1]
 		opts := []string{"rw", "rbind", "rprivate"}
 		if len(parts) == 3 {
-			opts = strings.Split(parts[2], ",")
+			opts = append(strings.Split(parts[2], ","), "rbind")
 		}
 		mounts[dest] = specs.Mount{Destination: dest, Type: "bind", Source: src, Options: opts}
 	}


### PR DESCRIPTION
From [the docs](https://docs.docker.com/engine/reference/run/#volume-shared-filesystems), `rbind` is not an option in the docker command line, but always seems to be applied by the daemon (code [here](https://github.com/moby/moby/blob/master/daemon/oci_linux.go#L553-L561) and [here](https://github.com/moby/moby/blob/103f2e56bf753019a4013a2722f908a3ee1bc558/daemon/volumes_unix.go#L195 
)). Do the same for the moby tool itself.

Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>