### PR TITLE
trust: parsing fixes and tests

### DIFF
--- a/cmd/moby/build.go
+++ b/cmd/moby/build.go
@@ -149,7 +149,23 @@ func enforceContentTrust(fullImageName string, config *TrustConfig) bool {
 	}
 
 	for _, org := range config.Org {
-		if strings.HasPrefix(fullImageName, org+"/") {
+		var imgOrg string
+		splitName := strings.Split(fullImageName, "/")
+		switch len(splitName) {
+		case 0:
+			// if the image is empty, return false
+			return false
+		case 1:
+			// for single names like nginx, use library
+			imgOrg = "library"
+		case 2:
+			// for names that assume docker hub, like linxukit/alpine, take the first split
+			imgOrg = splitName[0]
+		default:
+			// for names that include the registry, the second piece is the org, ex: docker.io/library/alpine
+			imgOrg = splitName[1]
+		}
+		if imgOrg == org {
 			return true
 		}
 	}

--- a/cmd/moby/build.go
+++ b/cmd/moby/build.go
@@ -137,11 +137,13 @@ func enforceContentTrust(fullImageName string, config *TrustConfig) bool {
 		}
 		// Also check for an image name only match
 		// by removing a possible tag (with possibly added digest):
-		if img == strings.TrimSuffix(fullImageName, ":") {
+		imgAndTag := strings.Split(fullImageName, ":")
+		if len(imgAndTag) >= 2 && img == imgAndTag[0] {
 			return true
 		}
 		// and by removing a possible digest:
-		if img == strings.TrimSuffix(fullImageName, "@sha256:") {
+		imgAndDigest := strings.Split(fullImageName, "@sha256:")
+		if len(imgAndDigest) >= 2 && img == imgAndDigest[0] {
 			return true
 		}
 	}

--- a/cmd/moby/trust_test.go
+++ b/cmd/moby/trust_test.go
@@ -1,52 +1,58 @@
 package main
 
-import (
-	"testing"
-
-	"github.com/stretchr/testify/require"
-)
+import "testing"
 
 func TestEnforceContentTrust(t *testing.T) {
-	// Simple positive and negative cases for Image subkey
-	require.True(t, enforceContentTrust("image", &TrustConfig{Image: []string{"image"}}))
-	require.True(t, enforceContentTrust("image", &TrustConfig{Image: []string{"more", "than", "one", "image"}}))
-	require.True(t, enforceContentTrust("image", &TrustConfig{Image: []string{"more", "than", "one", "image"}, Org: []string{"random", "orgs"}}))
+	type enforceContentTrustCase struct {
+		result      bool
+		imageName   string
+		trustConfig *TrustConfig
+	}
+	testCases := []enforceContentTrustCase{
+		// Simple positive and negative cases for Image subkey
+		{true, "image", &TrustConfig{Image: []string{"image"}}},
+		{true, "image", &TrustConfig{Image: []string{"more", "than", "one", "image"}}},
+		{true, "image", &TrustConfig{Image: []string{"more", "than", "one", "image"}, Org: []string{"random", "orgs"}}},
+		{false, "image", &TrustConfig{}},
+		{false, "image", &TrustConfig{Image: []string{"not", "in", "here!"}}},
+		{false, "image", &TrustConfig{Image: []string{"not", "in", "here!"}, Org: []string{""}}},
 
-	require.False(t, enforceContentTrust("image", &TrustConfig{}))
-	require.False(t, enforceContentTrust("image", &TrustConfig{Image: []string{"not", "in", "here!"}}))
-	require.False(t, enforceContentTrust("image", &TrustConfig{Image: []string{"not", "in", "here!"}, Org: []string{""}}))
+		// Tests for Image subkey with tags
+		{true, "image:tag", &TrustConfig{Image: []string{"image:tag"}}},
+		{true, "image:tag", &TrustConfig{Image: []string{"image"}}},
+		{false, "image:tag", &TrustConfig{Image: []string{"image:otherTag"}}},
+		{false, "image:tag", &TrustConfig{Image: []string{"image@sha256:abc123"}}},
 
-	// Tests for Image subkey with tags
-	require.True(t, enforceContentTrust("image:tag", &TrustConfig{Image: []string{"image:tag"}}))
-	require.True(t, enforceContentTrust("image:tag", &TrustConfig{Image: []string{"image"}}))
-	require.False(t, enforceContentTrust("image:tag", &TrustConfig{Image: []string{"image:otherTag"}}))
-	require.False(t, enforceContentTrust("image:tag", &TrustConfig{Image: []string{"image@sha256:abc123"}}))
+		// Tests for Image subkey with digests
+		{true, "image@sha256:abc123", &TrustConfig{Image: []string{"image@sha256:abc123"}}},
+		{true, "image@sha256:abc123", &TrustConfig{Image: []string{"image"}}},
+		{false, "image@sha256:abc123", &TrustConfig{Image: []string{"image:Tag"}}},
+		{false, "image@sha256:abc123", &TrustConfig{Image: []string{"image@sha256:def456"}}},
 
-	// Tests for Image subkey with digests
-	require.True(t, enforceContentTrust("image@sha256:abc123", &TrustConfig{Image: []string{"image@sha256:abc123"}}))
-	require.True(t, enforceContentTrust("image@sha256:abc123", &TrustConfig{Image: []string{"image"}}))
-	require.False(t, enforceContentTrust("image@sha256:abc123", &TrustConfig{Image: []string{"image:Tag"}}))
-	require.False(t, enforceContentTrust("image@sha256:abc123", &TrustConfig{Image: []string{"image@sha256:def456"}}))
+		// Tests for Image subkey with digests
+		{true, "image@sha256:abc123", &TrustConfig{Image: []string{"image@sha256:abc123"}}},
+		{true, "image@sha256:abc123", &TrustConfig{Image: []string{"image"}}},
+		{false, "image@sha256:abc123", &TrustConfig{Image: []string{"image:Tag"}}},
+		{false, "image@sha256:abc123", &TrustConfig{Image: []string{"image@sha256:def456"}}},
 
-	// Tests for Image subkey with digests
-	require.True(t, enforceContentTrust("image@sha256:abc123", &TrustConfig{Image: []string{"image@sha256:abc123"}}))
-	require.True(t, enforceContentTrust("image@sha256:abc123", &TrustConfig{Image: []string{"image"}}))
-	require.False(t, enforceContentTrust("image@sha256:abc123", &TrustConfig{Image: []string{"image:Tag"}}))
-	require.False(t, enforceContentTrust("image@sha256:abc123", &TrustConfig{Image: []string{"image@sha256:def456"}}))
+		// Tests for Org subkey
+		{true, "linuxkit/image", &TrustConfig{Image: []string{"notImage"}, Org: []string{"linuxkit"}}},
+		{true, "linuxkit/differentImage", &TrustConfig{Image: []string{}, Org: []string{"linuxkit"}}},
+		{true, "linuxkit/differentImage:tag", &TrustConfig{Image: []string{}, Org: []string{"linuxkit"}}},
+		{true, "linuxkit/differentImage@sha256:abc123", &TrustConfig{Image: []string{}, Org: []string{"linuxkit"}}},
+		{false, "linuxkit/differentImage", &TrustConfig{Image: []string{}, Org: []string{"notlinuxkit"}}},
+		{false, "linuxkit/differentImage:tag", &TrustConfig{Image: []string{}, Org: []string{"notlinuxkit"}}},
+		{false, "linuxkit/differentImage@sha256:abc123", &TrustConfig{Image: []string{}, Org: []string{"notlinuxkit"}}},
 
-	// Tests for Org subkey
-	require.True(t, enforceContentTrust("linuxkit/image", &TrustConfig{Image: []string{"notImage"}, Org: []string{"linuxkit"}}))
-	require.True(t, enforceContentTrust("linuxkit/differentImage", &TrustConfig{Image: []string{}, Org: []string{"linuxkit"}}))
-	require.True(t, enforceContentTrust("linuxkit/differentImage:tag", &TrustConfig{Image: []string{}, Org: []string{"linuxkit"}}))
-	require.True(t, enforceContentTrust("linuxkit/differentImage@sha256:abc123", &TrustConfig{Image: []string{}, Org: []string{"linuxkit"}}))
-
-	require.False(t, enforceContentTrust("linuxkit/differentImage", &TrustConfig{Image: []string{}, Org: []string{"notlinuxkit"}}))
-	require.False(t, enforceContentTrust("linuxkit/differentImage:tag", &TrustConfig{Image: []string{}, Org: []string{"notlinuxkit"}}))
-	require.False(t, enforceContentTrust("linuxkit/differentImage@sha256:abc123", &TrustConfig{Image: []string{}, Org: []string{"notlinuxkit"}}))
-
-	// Tests for Org with library organization
-	require.True(t, enforceContentTrust("nginx", &TrustConfig{Image: []string{}, Org: []string{"library"}}))
-	require.True(t, enforceContentTrust("nginx:alpine", &TrustConfig{Image: []string{}, Org: []string{"library"}}))
-	require.True(t, enforceContentTrust("library/nginx:alpine", &TrustConfig{Image: []string{}, Org: []string{"library"}}))
-	require.False(t, enforceContentTrust("nginx", &TrustConfig{Image: []string{}, Org: []string{"notLibrary"}}))
+		// Tests for Org with library organization
+		{true, "nginx", &TrustConfig{Image: []string{}, Org: []string{"library"}}},
+		{true, "nginx:alpine", &TrustConfig{Image: []string{}, Org: []string{"library"}}},
+		{true, "library/nginx:alpine", &TrustConfig{Image: []string{}, Org: []string{"library"}}},
+		{false, "nginx", &TrustConfig{Image: []string{}, Org: []string{"notLibrary"}}},
+	}
+	for _, testCase := range testCases {
+		if enforceContentTrust(testCase.imageName, testCase.trustConfig) != testCase.result {
+			t.Errorf("incorrect trust enforcement result for %s against configuration %v, expected: %v", testCase.imageName, testCase.trustConfig, testCase.result)
+		}
+	}
 }

--- a/cmd/moby/trust_test.go
+++ b/cmd/moby/trust_test.go
@@ -43,4 +43,10 @@ func TestEnforceContentTrust(t *testing.T) {
 	require.False(t, enforceContentTrust("linuxkit/differentImage", &TrustConfig{Image: []string{}, Org: []string{"notlinuxkit"}}))
 	require.False(t, enforceContentTrust("linuxkit/differentImage:tag", &TrustConfig{Image: []string{}, Org: []string{"notlinuxkit"}}))
 	require.False(t, enforceContentTrust("linuxkit/differentImage@sha256:abc123", &TrustConfig{Image: []string{}, Org: []string{"notlinuxkit"}}))
+
+	// Tests for Org with library organization
+	require.True(t, enforceContentTrust("nginx", &TrustConfig{Image: []string{}, Org: []string{"library"}}))
+	require.True(t, enforceContentTrust("nginx:alpine", &TrustConfig{Image: []string{}, Org: []string{"library"}}))
+	require.True(t, enforceContentTrust("library/nginx:alpine", &TrustConfig{Image: []string{}, Org: []string{"library"}}))
+	require.False(t, enforceContentTrust("nginx", &TrustConfig{Image: []string{}, Org: []string{"notLibrary"}}))
 }

--- a/cmd/moby/trust_test.go
+++ b/cmd/moby/trust_test.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEnforceContentTrust(t *testing.T) {
+	// Simple positive and negative cases for Image subkey
+	require.True(t, enforceContentTrust("image", &TrustConfig{Image: []string{"image"}}))
+	require.True(t, enforceContentTrust("image", &TrustConfig{Image: []string{"more", "than", "one", "image"}}))
+	require.True(t, enforceContentTrust("image", &TrustConfig{Image: []string{"more", "than", "one", "image"}, Org: []string{"random", "orgs"}}))
+
+	require.False(t, enforceContentTrust("image", &TrustConfig{}))
+	require.False(t, enforceContentTrust("image", &TrustConfig{Image: []string{"not", "in", "here!"}}))
+	require.False(t, enforceContentTrust("image", &TrustConfig{Image: []string{"not", "in", "here!"}, Org: []string{""}}))
+
+	// Tests for Image subkey with tags
+	require.True(t, enforceContentTrust("image:tag", &TrustConfig{Image: []string{"image:tag"}}))
+	require.True(t, enforceContentTrust("image:tag", &TrustConfig{Image: []string{"image"}}))
+	require.False(t, enforceContentTrust("image:tag", &TrustConfig{Image: []string{"image:otherTag"}}))
+	require.False(t, enforceContentTrust("image:tag", &TrustConfig{Image: []string{"image@sha256:abc123"}}))
+
+	// Tests for Image subkey with digests
+	require.True(t, enforceContentTrust("image@sha256:abc123", &TrustConfig{Image: []string{"image@sha256:abc123"}}))
+	require.True(t, enforceContentTrust("image@sha256:abc123", &TrustConfig{Image: []string{"image"}}))
+	require.False(t, enforceContentTrust("image@sha256:abc123", &TrustConfig{Image: []string{"image:Tag"}}))
+	require.False(t, enforceContentTrust("image@sha256:abc123", &TrustConfig{Image: []string{"image@sha256:def456"}}))
+
+	// Tests for Image subkey with digests
+	require.True(t, enforceContentTrust("image@sha256:abc123", &TrustConfig{Image: []string{"image@sha256:abc123"}}))
+	require.True(t, enforceContentTrust("image@sha256:abc123", &TrustConfig{Image: []string{"image"}}))
+	require.False(t, enforceContentTrust("image@sha256:abc123", &TrustConfig{Image: []string{"image:Tag"}}))
+	require.False(t, enforceContentTrust("image@sha256:abc123", &TrustConfig{Image: []string{"image@sha256:def456"}}))
+
+	// Tests for Org subkey
+	require.True(t, enforceContentTrust("linuxkit/image", &TrustConfig{Image: []string{"notImage"}, Org: []string{"linuxkit"}}))
+	require.True(t, enforceContentTrust("linuxkit/differentImage", &TrustConfig{Image: []string{}, Org: []string{"linuxkit"}}))
+	require.True(t, enforceContentTrust("linuxkit/differentImage:tag", &TrustConfig{Image: []string{}, Org: []string{"linuxkit"}}))
+	require.True(t, enforceContentTrust("linuxkit/differentImage@sha256:abc123", &TrustConfig{Image: []string{}, Org: []string{"linuxkit"}}))
+
+	require.False(t, enforceContentTrust("linuxkit/differentImage", &TrustConfig{Image: []string{}, Org: []string{"notlinuxkit"}}))
+	require.False(t, enforceContentTrust("linuxkit/differentImage:tag", &TrustConfig{Image: []string{}, Org: []string{"notlinuxkit"}}))
+	require.False(t, enforceContentTrust("linuxkit/differentImage@sha256:abc123", &TrustConfig{Image: []string{}, Org: []string{"notlinuxkit"}}))
+}

--- a/test/test.yml
+++ b/test/test.yml
@@ -31,6 +31,5 @@ files:
     contents: '{"debug": true}'
 trust:
   org:
+    - library
     - linuxkit
-  image:
-    - nginx:alpine


### PR DESCRIPTION
- the smart tag/digest chopping logic had a bug, included a fix and unit tests - I intend to add more unit tests for other parts of the trust code.

- I split out the vendoring commit: related to our discussion in slack, there were other changes for other packages.  I deleted the `/vendor` directory and revendored with `vndr`

- also added smarter Org parsing logic to allow for `library` to be specifiable to perform trust checks on official images

<img src="https://s-media-cache-ak0.pinimg.com/originals/df/26/5b/df265be4d5e43ee5ac858c54bb91b667.jpg" width="400"></img>