### PR TITLE
Validate output before doing the work

### DIFF
--- a/cmd/moby/build.go
+++ b/cmd/moby/build.go
@@ -65,6 +65,13 @@ func build(args []string) {
 
 	log.Debugf("Outputs selected: %s", buildOut.String())
 
+	err := validateOutputs(buildOut)
+	if err != nil {
+		log.Errorf("Error parsing outputs: %v", err)
+		buildCmd.Usage()
+		os.Exit(1)
+	}
+
 	if len(remArgs) == 0 {
 		fmt.Println("Please specify a configuration file")
 		buildCmd.Usage()

--- a/cmd/moby/output.go
+++ b/cmd/moby/output.go
@@ -119,15 +119,29 @@ var outFuns = map[string]func(string, []byte) error{
 	},
 }
 
-func outputs(base string, image []byte, out outputList) error {
-	log.Debugf("output: %v %s", out, base)
+func validateOutputs(out outputList) error {
+	log.Debugf("validating output: %v", out)
 
 	for _, o := range out {
 		f := outFuns[o]
 		if f == nil {
 			return fmt.Errorf("Unknown output type %s", o)
 		}
-		err := f(base, image)
+	}
+
+	return nil
+}
+
+func outputs(base string, image []byte, out outputList) error {
+	log.Debugf("output: %v %s", out, base)
+
+	err := validateOutputs(out)
+	if err != nil {
+		return err
+	}
+	for _, o := range out {
+		f := outFuns[o]
+		err = f(base, image)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
With the new build output command, it's possible to have a typo in the desired output, that doesn't get validated till all of the building/pulling is about done.

This validates the build output prior to doing any work. 

![thesaurus](https://i.redditmedia.com/u2kOPHM8bP13yCCNovF2nID8AZkXQKaBBOA6urYyFUM.jpg?w=576&s=2f96387c583fca513b61000bad1684b0)