### PR TITLE
add default trust config and cache dir

### DIFF
--- a/cmd/moby/trust.go
+++ b/cmd/moby/trust.go
@@ -10,7 +10,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
-	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -62,14 +62,8 @@ func TrustedReference(image string) (reference.Reference, error) {
 		return nil, err
 	}
 
-	tmpTrustDir, err := ioutil.TempDir("", "notary")
-	if err != nil {
-		return nil, err
-	}
-	defer os.Remove(tmpTrustDir)
-
 	nRepo, err := notaryClient.NewNotaryRepository(
-		tmpTrustDir,
+		trustDirectory(),
 		gun,
 		server,
 		rt,
@@ -105,6 +99,10 @@ func getTrustServer(gun string) (string, error) {
 		return "https://notary.docker.io", nil
 	}
 	return "", errors.New("non-hub images not yet supported")
+}
+
+func trustDirectory() string {
+	return filepath.Join(MobyDir, "trust")
 }
 
 type credentialStore struct {


### PR DESCRIPTION
As discussed on the linuxkit community slack, introduce a `~/.moby/trust` by default directory on the host intended for caching important trust data and/or future configuration. 

```
🐳 $ moby --help
<..snip..>

Options:
  -d string
    	Configuration directory (default /Users/riyaz/.moby)
```

This will optimize notary lookups since if we determine we have the most up-to-date trust data cached we don't need to request as much data from the notary server. Also provides security benefits since we pin local metadata and prevent version rollback.

<img src="https://s-media-cache-ak0.pinimg.com/originals/0f/6b/e3/0f6be390b0411de87c613220452d0b25.jpg" width="250"></img>

Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>