### PR TITLE
Add the temporary directories under ~/.moby

### DIFF
--- a/cmd/moby/linuxkit.go
+++ b/cmd/moby/linuxkit.go
@@ -90,7 +90,7 @@ func writeKernelInitrd(filename string, kernel []byte, initrd []byte, cmdline st
 func outputLinuxKit(format string, filename string, kernel []byte, initrd []byte, cmdline string, size int, hyperkit bool) error {
 	log.Debugf("output linuxkit generated img: %s %s size %d", format, filename, size)
 
-	tmp, err := ioutil.TempDir("", "moby")
+	tmp, err := ioutil.TempDir(filepath.Join(MobyDir, "tmp"), "moby")
 	if err != nil {
 		return err
 	}

--- a/cmd/moby/main.go
+++ b/cmd/moby/main.go
@@ -97,6 +97,11 @@ func main() {
 		log.Fatalf("Could not create config directory [%s]: %v", MobyDir, err)
 	}
 
+	err = os.MkdirAll(filepath.Join(MobyDir, "tmp"), 0755)
+	if err != nil {
+		log.Fatalf("Could not create config tmp directory [%s]: %v", filepath.Join(MobyDir, "tmp"), err)
+	}
+
 	switch args[0] {
 	case "build":
 		build(args[1:])

--- a/cmd/moby/output.go
+++ b/cmd/moby/output.go
@@ -82,10 +82,11 @@ var outFuns = map[string]func(string, []byte, int, bool) error{
 		if err != nil {
 			return fmt.Errorf("Error converting to initrd: %v", err)
 		}
-		tmp, err := ioutil.TempDir("", "img-gz")
+		tmp, err := ioutil.TempDir(filepath.Join(MobyDir, "tmp"), "img-gz")
 		if err != nil {
 			return err
 		}
+		defer os.RemoveAll(tmp)
 		err = outputLinuxKit("raw", filepath.Join(tmp, "uncompressed.img"), kernel, initrd, cmdline, size, hyperkit)
 		if err != nil {
 			return fmt.Errorf("Error writing img-gz output: %v", err)
@@ -112,10 +113,6 @@ var outFuns = map[string]func(string, []byte, int, bool) error{
 		if err != nil {
 			return err
 		}
-		err = os.RemoveAll(tmp)
-		if err != nil {
-			return err
-		}
 		return nil
 	},
 	"gcp-img": func(base string, image []byte, size int, hyperkit bool) error {
@@ -125,10 +122,11 @@ var outFuns = map[string]func(string, []byte, int, bool) error{
 		if err != nil {
 			return fmt.Errorf("Error converting to initrd: %v", err)
 		}
-		tmp, err := ioutil.TempDir("", "gcp-img")
+		tmp, err := ioutil.TempDir(filepath.Join(MobyDir, "tmp"), "gcp-img")
 		if err != nil {
 			return err
 		}
+		defer os.RemoveAll(tmp)
 		err = outputLinuxKit("raw", filepath.Join(tmp, "disk.raw"), kernel, initrd, cmdline, size, hyperkit)
 		if err != nil {
 			return fmt.Errorf("Error writing gcp-img output: %v", err)
@@ -170,10 +168,6 @@ var outFuns = map[string]func(string, []byte, int, bool) error{
 			return err
 		}
 		err = out.Close()
-		if err != nil {
-			return err
-		}
-		err = os.RemoveAll(tmp)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
qemu calls in a container use `-v` with a single path from the image so
other resources must be under this.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>