### PR TITLE
trust: check local image cache to not pull every time

### DIFF
--- a/cmd/moby/build.go
+++ b/cmd/moby/build.go
@@ -221,13 +221,6 @@ func buildInternal(m Moby, pull bool) []byte {
 	w := new(bytes.Buffer)
 	iw := tar.NewWriter(w)
 
-	if pull || enforceContentTrust(m.Kernel.Image, &m.Trust) {
-		log.Infof("Pull kernel image: %s", m.Kernel.Image)
-		err := dockerPull(m.Kernel.Image, enforceContentTrust(m.Kernel.Image, &m.Trust))
-		if err != nil {
-			log.Fatalf("Could not pull image %s: %v", m.Kernel.Image, err)
-		}
-	}
 	if m.Kernel.Image != "" {
 		// get kernel and initrd tarball from container
 		log.Infof("Extract kernel image: %s", m.Kernel.Image)

--- a/cmd/moby/build.go
+++ b/cmd/moby/build.go
@@ -262,13 +262,14 @@ func buildInternal(m Moby, pull bool) []byte {
 	}
 	for i, image := range m.Onboot {
 		log.Infof("  Create OCI config for %s", image.Image)
-		config, err := ConfigToOCI(image)
+		useTrust := enforceContentTrust(image.Image, &m.Trust)
+		config, err := ConfigToOCI(image, useTrust)
 		if err != nil {
 			log.Fatalf("Failed to create config.json for %s: %v", image.Image, err)
 		}
 		so := fmt.Sprintf("%03d", i)
 		path := "containers/onboot/" + so + "-" + image.Name
-		out, err := ImageBundle(path, image.Image, config, enforceContentTrust(image.Image, &m.Trust), pull)
+		out, err := ImageBundle(path, image.Image, config, useTrust, pull)
 		if err != nil {
 			log.Fatalf("Failed to extract root filesystem for %s: %v", image.Image, err)
 		}
@@ -281,12 +282,13 @@ func buildInternal(m Moby, pull bool) []byte {
 	}
 	for _, image := range m.Services {
 		log.Infof("  Create OCI config for %s", image.Image)
-		config, err := ConfigToOCI(image)
+		useTrust := enforceContentTrust(image.Image, &m.Trust)
+		config, err := ConfigToOCI(image, useTrust)
 		if err != nil {
 			log.Fatalf("Failed to create config.json for %s: %v", image.Image, err)
 		}
 		path := "containers/services/" + image.Name
-		out, err := ImageBundle(path, image.Image, config, enforceContentTrust(image.Image, &m.Trust), pull)
+		out, err := ImageBundle(path, image.Image, config, useTrust, pull)
 		if err != nil {
 			log.Fatalf("Failed to extract root filesystem for %s: %v", image.Image, err)
 		}

--- a/cmd/moby/config.go
+++ b/cmd/moby/config.go
@@ -202,7 +202,7 @@ func NewImage(config []byte) (MobyImage, error) {
 }
 
 // ConfigToOCI converts a config specification to an OCI config file
-func ConfigToOCI(image MobyImage) ([]byte, error) {
+func ConfigToOCI(image MobyImage, trust bool) ([]byte, error) {
 
 	// TODO pass through same docker client to all functions
 	cli, err := dockerClient()
@@ -210,7 +210,7 @@ func ConfigToOCI(image MobyImage) ([]byte, error) {
 		return []byte{}, err
 	}
 
-	inspect, err := dockerInspectImage(cli, image.Image)
+	inspect, err := dockerInspectImage(cli, image.Image, trust)
 	if err != nil {
 		return []byte{}, err
 	}

--- a/cmd/moby/docker.go
+++ b/cmd/moby/docker.go
@@ -175,13 +175,13 @@ func dockerClient() (*client.Client, error) {
 	return client.NewEnvClient()
 }
 
-func dockerInspectImage(cli *client.Client, image string) (types.ImageInspect, error) {
+func dockerInspectImage(cli *client.Client, image string, trustedPull bool) (types.ImageInspect, error) {
 	log.Debugf("docker inspect image: %s", image)
 
 	inspect, _, err := cli.ImageInspectWithRaw(context.Background(), image)
 	if err != nil {
 		if client.IsErrImageNotFound(err) {
-			pullErr := dockerPull(image, true, false)
+			pullErr := dockerPull(image, true, trustedPull)
 			if pullErr != nil {
 				return types.ImageInspect{}, pullErr
 			}

--- a/cmd/moby/image.go
+++ b/cmd/moby/image.go
@@ -94,8 +94,7 @@ func imageTar(image, prefix string, tw *tar.Writer, trust bool, pull bool) error
 	}
 
 	if pull || trust {
-		log.Infof("Pull image: %s", image)
-		err := dockerPull(image, trust)
+		err := dockerPull(image, pull, trust)
 		if err != nil {
 			return fmt.Errorf("Could not pull image %s: %v", image, err)
 		}
@@ -104,8 +103,7 @@ func imageTar(image, prefix string, tw *tar.Writer, trust bool, pull bool) error
 	if err != nil {
 		// if the image wasn't found, pull it down.  Bail on other errors.
 		if strings.Contains(err.Error(), "No such image") {
-			log.Infof("Pull image: %s", image)
-			err := dockerPull(image, trust)
+			err := dockerPull(image, true, trust)
 			if err != nil {
 				return fmt.Errorf("Could not pull image %s: %v", image, err)
 			}

--- a/cmd/moby/trust.go
+++ b/cmd/moby/trust.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	log "github.com/Sirupsen/logrus"
 	"github.com/docker/distribution/reference"
 	"github.com/docker/distribution/registry/client/auth"
 	"github.com/docker/distribution/registry/client/auth/challenge"
@@ -59,7 +60,8 @@ func TrustedReference(image string) (reference.Reference, error) {
 
 	rt, err := GetReadOnlyAuthTransport(server, []string{gun}, "", "", "")
 	if err != nil {
-		return nil, err
+		log.Debugf("failed to reach %s notary server for repo: %s, falling back to cache: %v", server, gun, err)
+		rt = nil
 	}
 
 	nRepo, err := notaryClient.NewNotaryRepository(


### PR DESCRIPTION
- When using `trust`: check the local image cache for the newly translated image reference before issuing a pull API request, unless force `-pull` was specified
- Fall back to local `trust` cache when offline, to enable offline trusted builds if local trust data already exists.  Note that notary library will output `warn` level log statements, which will be shown on output for the current default log level
- Remove an extraneous kernel pull, since this is already handled in the `imageTar` logic
- Only print `Pull image...` if we actually issue the API request to pull down remote data. Additionally, print the full reference of the image, which may be updated from content trust:
```
Extract kernel image: linuxkit/kernel:4.9.x
Pull image: docker.io/linuxkit/kernel:4.9.x@sha256:a0bc40648edf7e73b9801f2887b0aefab9ec1878dcbe3bcff8ea48ebfffdb4d7
Add init containers:
Process init image: linuxkit/init:4fc8aa82ab34d62d510575c8fbe0c58b7ba9c480
Pull image: docker.io/linuxkit/init:4fc8aa82ab34d62d510575c8fbe0c58b7ba9c480@sha256:eb56131b5abeb102af3099cc14411470d3cdcc9eea7319bae21ada5b568ce8d0
Process init image: linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
Pull image: docker.io/linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f@sha256:e8603bafe28d72887a2db01886d326a6e309e6ad3b2ad88bb7cee9be260d2fc7
```

Closes #57

<img src="https://s-media-cache-ak0.pinimg.com/736x/d4/26/0c/d4260c4c7a50d949e13291b7864d3a03.jpg" width="250"></img>

Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>