### PR TITLE
Use streaming output where possible

### DIFF
--- a/cmd/moby/linuxkit.go
+++ b/cmd/moby/linuxkit.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"fmt"
 	"io"
@@ -58,7 +59,9 @@ func ensureLinuxkitImage(name string) error {
 		return err
 	}
 	// TODO pass through --pull to here
-	image := buildInternal(m, false)
+	buf := new(bytes.Buffer)
+	buildInternal(m, buf, false)
+	image := buf.Bytes()
 	kernel, initrd, cmdline, err := tarToInitrd(image)
 	if err != nil {
 		return fmt.Errorf("Error converting to initrd: %v", err)

--- a/cmd/moby/output.go
+++ b/cmd/moby/output.go
@@ -23,13 +23,6 @@ const (
 )
 
 var outFuns = map[string]func(string, []byte, int, bool) error{
-	"tar": func(base string, image []byte, size int, hyperkit bool) error {
-		err := outputTar(base, image)
-		if err != nil {
-			return fmt.Errorf("Error writing tar output: %v", err)
-		}
-		return nil
-	},
 	"kernel+initrd": func(base string, image []byte, size int, hyperkit bool) error {
 		kernel, initrd, cmdline, err := tarToInitrd(image)
 		if err != nil {
@@ -335,10 +328,4 @@ func outputKernelInitrd(base string, kernel []byte, initrd []byte, cmdline strin
 		return err
 	}
 	return nil
-}
-
-func outputTar(base string, initrd []byte) error {
-	log.Debugf("output tar: %s", base)
-	log.Infof("  %s", base+".tar")
-	return ioutil.WriteFile(base+".tar", initrd, os.FileMode(0644))
 }


### PR DESCRIPTION
The `tar` output format (and others to come) will now output using streaming rather than buffering everything up. Allow them to be output to `stdout` and files in a streaming fashion. This should save a lot of memory on large outputs.

eg you can see list of generated files with
```
moby -q build -output tar -o - linuxkit.yml | tar tf -
```

The LinuxKit disk outputs can't do this, as they have to construct whole disks. So there are two kinds of output. We will probably split these into "build" and "package" later. Most of the host outputs will probably be the streaming type and the LinuxKit ones not.

Haven't changed the CLI to some sort of "package" method as haven't worked out a nice design thats not too verbose yet.