### PR TITLE
Add an output format for running images with Docker

### DIFF
--- a/cmd/moby/linuxkit.go
+++ b/cmd/moby/linuxkit.go
@@ -60,7 +60,7 @@ func ensureLinuxkitImage(name string) error {
 	}
 	// TODO pass through --pull to here
 	buf := new(bytes.Buffer)
-	buildInternal(m, buf, false)
+	buildInternal(m, buf, false, nil)
 	image := buf.Bytes()
 	kernel, initrd, cmdline, err := tarToInitrd(image)
 	if err != nil {

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,23 @@
+Examples of building an image to run on LinuxKit or on a host
+
+Currently the `moby` tool can output formats suitable for LinuxKit to boot on
+a VM, and also some formats for running natively.
+
+The `docker` format adds a `Dockerfile` to the tarball and expects a similar
+file structure to `LinuxKit` but with the low level system setup pieces removed
+as this will already be set up in a container.
+
+The `mobytest/init-container` image in this repository has an example setup that
+initialises `containerd` in exactly the same way as it runs in LinuxKit, which will
+then start the `onboot` and `service` containers. The example below shows how you
+can run `nginx` on either of these base configs.
+
+```
+moby build -output docker -o - docker.yml nginx.yml | docker build -t dockertest -
+docker run -d -p 80:80 --privileged dockertest
+
+moby build -output kernel+initrd linuxkit.yml nginx.yml
+linuxkit run nginx
+```
+
+Both of these will run the same `nginx` either in a VM or a container.

--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -1,0 +1,9 @@
+init:
+  - mobytest/init-container:b5de246b2790d74d53bae583a95c87869ca003e6
+  - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
+  - linuxkit/containerd:5749f2e9e65395cc6635229e8da0e0d484320ddf
+  - linuxkit/ca-certificates:75cf419fb58770884c3464eb687ec8dfc704169d
+trust:
+  org:
+    - linuxkit
+    - mobytest

--- a/examples/linuxkit.yml
+++ b/examples/linuxkit.yml
@@ -1,0 +1,18 @@
+kernel:
+  image: "linuxkit/kernel:4.9.x"
+  cmdline: "console=ttyS0"
+init:
+  - linuxkit/init:1b8a7e394d2ec2f1fdb4d67645829d1b5bdca037
+  - linuxkit/runc:3a4e6cbf15470f62501b019b55e1caac5ee7689f
+  - linuxkit/containerd:5749f2e9e65395cc6635229e8da0e0d484320ddf
+  - linuxkit/ca-certificates:75cf419fb58770884c3464eb687ec8dfc704169d
+onboot:
+  - name: dhcpcd
+    image: "linuxkit/dhcpcd:7d2b8aaaf20c24ad7d11a5ea2ea5b4a80dc966f1"
+    command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
+services:
+  - name: rngd
+    image: "linuxkit/rngd:1fa4de44c961bb5075647181891a3e7e7ba51c31"
+trust:
+  org:
+    - linuxkit

--- a/examples/nginx.yml
+++ b/examples/nginx.yml
@@ -1,0 +1,12 @@
+services:
+  - name: nginx
+    image: "nginx:alpine"
+    capabilities:
+     - CAP_NET_BIND_SERVICE
+     - CAP_CHOWN
+     - CAP_SETUID
+     - CAP_SETGID
+     - CAP_DAC_OVERRIDE
+trust:
+  org:
+    - library

--- a/pkg/init-container/Dockerfile
+++ b/pkg/init-container/Dockerfile
@@ -1,0 +1,14 @@
+FROM linuxkit/alpine:630ee558e4869672fae230c78364e367b8ea67a9 AS mirror
+RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
+RUN apk add --no-cache --initdb -p /out alpine-baselayout busybox musl tini
+
+# Remove apk residuals. We have a read-only rootfs, so apk is of no use.
+RUN rm -rf /out/etc/apk /out/lib/apk /out/var/cache
+
+FROM scratch
+ENTRYPOINT []
+CMD []
+WORKDIR /
+COPY --from=mirror /out/ /
+COPY etc etc/
+COPY bin bin/

--- a/pkg/init-container/Makefile
+++ b/pkg/init-container/Makefile
@@ -1,0 +1,15 @@
+.PHONY: tag push
+default: push
+
+ORG?=mobytest
+IMAGE=init-container
+DEPS=Dockerfile $(wildcard etc/init.d/*) $(wildcard bin/*)
+
+HASH?=$(shell git ls-tree HEAD -- ../$(notdir $(CURDIR)) | awk '{print $$3}')
+
+tag: $(DEPS)
+	docker build --no-cache --network=none -t $(ORG)/$(IMAGE):$(HASH) .
+
+push: tag
+	DOCKER_CONTENT_TRUST=1 docker pull $(ORG)/$(IMAGE):$(HASH) || \
+	DOCKER_CONTENT_TRUST=1 docker push $(ORG)/$(IMAGE):$(HASH)

--- a/pkg/init-container/bin/rc.init
+++ b/pkg/init-container/bin/rc.init
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# execute other init processes
+INITS="$(find /etc/init.d -type f | sort)"
+for f in $INITS
+do
+	$f &
+done
+
+wait

--- a/pkg/init-container/etc/init.d/010-containerd
+++ b/pkg/init-container/etc/init.d/010-containerd
@@ -1,0 +1,46 @@
+#!/bin/sh
+
+# set global ulimits TODO move to /etc/limits.conf
+ulimit -n 1048576
+ulimit -p unlimited
+
+# bring up containerd
+printf "\nStarting containerd\n"
+/usr/bin/containerd &
+
+# wait for socket to be there
+while [ ! -S /run/containerd/containerd.sock ]
+do
+	sleep 0.1
+done
+
+# start onboot containers, run to completion
+
+if [ -d /containers/onboot ]
+then
+	for f in $(find /containers/onboot -mindepth 1 -maxdepth 1 | sort)
+	do
+		base="$(basename $f)"
+		#/bin/mount --bind "$f/rootfs" "$f/rootfs"
+		#mount -o remount,rw "$f/rootfs"
+		/usr/bin/runc run --bundle "$f" "$(basename $f)"
+		printf " - $base\n"
+	done
+fi
+
+# start service containers
+
+if [ -d /containers/services ]
+then
+	for f in $(find /containers/services -mindepth 1 -maxdepth 1 | sort)
+	do
+		base="$(basename $f)"
+		#/bin/mount --bind "$f/rootfs" "$f/rootfs"
+		#mount -o remount,rw "$f/rootfs"
+		log="/var/log/$base.log"
+		ctr run --runtime-config "$f/config.json" --rootfs "$f/rootfs" --id "$(basename $f)" </dev/null 2>$log >$log &
+		printf " - $base\n"
+	done
+fi
+
+wait


### PR DESCRIPTION
This is first prototype for running images on the host. Next comes `systemd`, `deb` and `rpm`.

```
moby build -output docker -o - docker.yml nginx.yml | docker build -t dockertest -
docker run -d -p 80:80 --privileged dockertest

moby build -output kernel+initrd linuxkit.yml nginx.yml
linuxkit run nginx
```

Both of these will run the same `nginx` either in a VM or a container.

(note `--privileged` is required as we are running `containerd` and `runc` in the Docker container still, so they need to be able to do mounts etc. Also `runc` is excessive in the permissions it requires).

![hare](https://user-images.githubusercontent.com/482364/26885697-43baff32-4b9b-11e7-89c9-c5be49f212ed.jpg)
