### PR TITLE
Allow setting of mode in files section

### DIFF
--- a/cmd/moby/config.go
+++ b/cmd/moby/config.go
@@ -32,6 +32,7 @@ type Moby struct {
 		Symlink   string
 		Contents  string
 		Source    string
+		Mode      string
 	}
 }
 

--- a/cmd/moby/schema.go
+++ b/cmd/moby/schema.go
@@ -22,7 +22,8 @@ var schema = string(`
           "directory": {"type": "boolean"},
           "symlink": {"type": "string"},
           "contents": {"type": "string"},
-          "source": {"type": "string"}
+          "source": {"type": "string"},
+          "mode": {"type": "string"}
         }
     },
     "files": {


### PR DESCRIPTION
Also keep track of directory creation there, so you can explicitly
set directory permissions if required, and to avoid duplicates.

We should really keep track of files created elsewhere in the build
as well as we still might create some extras, but at least you can
set the write permisisons.

We can add uid, gid support too if required...

Signed-off-by: Justin Cormack <justin.cormack@docker.com>

cc @deitch you asked for this...