### PR TITLE
Remove absolute paths from files

### DIFF
--- a/cmd/moby/build.go
+++ b/cmd/moby/build.go
@@ -529,6 +529,10 @@ func filesystem(m Moby, tw *tar.Writer) error {
 		if f.Path == "" {
 			return errors.New("Did not specify path for file")
 		}
+		// tar archives should not have absolute paths
+		if f.Path[0] == os.PathSeparator {
+			f.Path = f.Path[1:]
+		}
 		mode := int64(0600)
 		if f.Directory {
 			mode = 0700


### PR DESCRIPTION
tarballs should only have relative paths in.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>