### PR TITLE
Allow ~ for home directory when specifying source of file

### DIFF
--- a/cmd/moby/build.go
+++ b/cmd/moby/build.go
@@ -558,7 +558,9 @@ func filesystem(m Moby, tw *tar.Writer) error {
 			if f.Source == "" {
 				return errors.New("Contents of file not specified")
 			}
-
+			if len(f.Source) > 2 && f.Source[:2] == "~/" {
+				f.Source = homeDir() + f.Source[1:]
+			}
 			contents, err := ioutil.ReadFile(f.Source)
 			if err != nil {
 				return err


### PR DESCRIPTION
Useful when adding ssh keys

Signed-off-by: Justin Cormack <justin.cormack@docker.com>