### PR TITLE
Do not force default hostname `moby`.

### DIFF
--- a/cmd/moby/image.go
+++ b/cmd/moby/image.go
@@ -23,11 +23,12 @@ type tarWriter interface {
 // cache as it would be much simpler.
 
 var exclude = map[string]bool{
-	".dockerenv":  true,
-	"Dockerfile":  true,
-	"dev/console": true,
-	"dev/pts":     true,
-	"dev/shm":     true,
+	".dockerenv":   true,
+	"Dockerfile":   true,
+	"dev/console":  true,
+	"dev/pts":      true,
+	"dev/shm":      true,
+	"etc/hostname": true,
 }
 
 var replace = map[string]string{
@@ -43,7 +44,6 @@ nameserver 8.8.4.4
 nameserver 2001:4860:4860::8888
 nameserver 2001:4860:4860::8844
 `,
-	"etc/hostname": "moby",
 }
 
 // tarPrefix creates the leading directories for a path


### PR DESCRIPTION
This disables the code in LinuxKit's `/bin/rc.init` which attempts to detect an
unconfigured hostname and generate a unique (ish) version from the MAC address.

Anyone who wants a specific fallback hostname can populate `etc/hostname`
through the `files` stanza in their `yml` file.

Signed-off-by: Ian Campbell <ian.campbell@docker.com>