### PR TITLE
Use hyperkit to make raw disks

### DIFF
--- a/cmd/moby/build.go
+++ b/cmd/moby/build.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strconv"
 	"strings"
@@ -94,7 +95,7 @@ func build(args []string) {
 	buildSize := buildCmd.String("size", "1024M", "Size for output image, if supported and fixed size")
 	buildPull := buildCmd.Bool("pull", false, "Always pull images")
 	buildDisableTrust := buildCmd.Bool("disable-content-trust", false, "Skip image trust verification specified in trust section of config (default false)")
-	buildHyperkit := buildCmd.Bool("hyperkit", false, "Use hyperkit for LinuxKit based builds where possible")
+	buildHyperkit := buildCmd.Bool("hyperkit", runtime.GOOS == "darwin", "Use hyperkit for LinuxKit based builds where possible")
 	buildCmd.Var(&buildOut, "output", "Output types to create [ "+strings.Join(outputTypes, " ")+" ]")
 
 	if err := buildCmd.Parse(args); err != nil {

--- a/cmd/moby/linuxkit.go
+++ b/cmd/moby/linuxkit.go
@@ -129,9 +129,14 @@ func outputLinuxKit(format string, filename string, kernel []byte, initrd []byte
 		return fmt.Errorf("Cannot find linuxkit executable, needed to build %s output type: %v", format, err)
 	}
 	commandLine := []string{"-q", "run", "qemu", "-disk", fmt.Sprintf("%s,size=%s,format=%s", filename, sizeString, format), "-disk", fmt.Sprintf("%s,format=raw", tardisk), "-kernel", imageFilename("mkimage")}
-	// if hyperkit && format == "raw" {
-	// TODO support hyperkit
-	// }
+	if hyperkit && format == "raw" {
+		state, err := ioutil.TempDir("", "s")
+		if err != nil {
+			return err
+		}
+		defer os.RemoveAll(state)
+		commandLine = []string{"-q", "run", "hyperkit", "-state", state, "-disk", fmt.Sprintf("%s,size=%s,format=%s", filename, sizeString, format), "-disk", fmt.Sprintf("%s,format=raw", tardisk), imageFilename("mkimage")}
+	}
 	log.Debugf("run %s: %v", linuxkit, commandLine)
 	cmd := exec.Command(linuxkit, commandLine...)
 	cmd.Stderr = os.Stderr


### PR DESCRIPTION
- enable the hyperkit option by default on MacOS
- use it for creating raw disk images

fix #68

Signed-off-by: Justin Cormack <justin.cormack@docker.com>