### PR TITLE
Allow creation of empty files

### DIFF
--- a/cmd/moby/config.go
+++ b/cmd/moby/config.go
@@ -31,7 +31,7 @@ type Moby struct {
 		Path      string
 		Directory bool
 		Symlink   string
-		Contents  string
+		Contents  *string
 		Source    string
 		Optional  bool
 		Mode      string

--- a/test/test.yml
+++ b/test/test.yml
@@ -29,6 +29,8 @@ services:
 files:
   - path: etc/docker/daemon.json
     contents: '{"debug": true}'
+  - path: /empty
+    contents: ""
 trust:
   org:
     - library


### PR DESCRIPTION
- change to a pointer type so we can distinguish empty from unset.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>