### PR TITLE
Pass a logger to the library parts of Moby

### DIFF
--- a/cmd/moby/config.go
+++ b/cmd/moby/config.go
@@ -9,7 +9,6 @@ import (
 	"strconv"
 	"strings"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/opencontainers/runtime-spec/specs-go"
@@ -155,8 +154,6 @@ func AppendConfig(m0, m1 Moby) Moby {
 
 // NewImage validates an parses yaml or json for a MobyImage
 func NewImage(config []byte) (MobyImage, error) {
-	log.Debugf("Reading label config: %s", string(config))
-
 	mi := MobyImage{}
 
 	// Parse raw yaml
@@ -220,7 +217,7 @@ func NewImage(config []byte) (MobyImage, error) {
 }
 
 // ConfigToOCI converts a config specification to an OCI config file
-func ConfigToOCI(image MobyImage, trust bool) ([]byte, error) {
+func ConfigToOCI(log Logger, image MobyImage, trust bool) ([]byte, error) {
 
 	// TODO pass through same docker client to all functions
 	cli, err := dockerClient()
@@ -228,7 +225,7 @@ func ConfigToOCI(image MobyImage, trust bool) ([]byte, error) {
 		return []byte{}, err
 	}
 
-	inspect, err := dockerInspectImage(cli, image.Image, trust)
+	inspect, err := dockerInspectImage(log, cli, image.Image, trust)
 	if err != nil {
 		return []byte{}, err
 	}

--- a/cmd/moby/linuxkit.go
+++ b/cmd/moby/linuxkit.go
@@ -9,8 +9,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-
-	log "github.com/Sirupsen/logrus"
 )
 
 var linuxkitYaml = map[string]string{"mkimage": `
@@ -37,7 +35,7 @@ func imageFilename(name string) string {
 	return filepath.Join(MobyDir, "linuxkit", name+"-"+fmt.Sprintf("%x", hash))
 }
 
-func ensureLinuxkitImage(name string) error {
+func ensureLinuxkitImage(log Logger, name string) error {
 	filename := imageFilename(name)
 	_, err1 := os.Stat(filename + "-kernel")
 	_, err2 := os.Stat(filename + "-initrd.img")
@@ -60,7 +58,7 @@ func ensureLinuxkitImage(name string) error {
 	}
 	// TODO pass through --pull to here
 	buf := new(bytes.Buffer)
-	buildInternal(m, buf, false, nil)
+	buildInternal(log, m, buf, false, nil)
 	image := buf.Bytes()
 	kernel, initrd, cmdline, err := tarToInitrd(image)
 	if err != nil {
@@ -90,7 +88,7 @@ func writeKernelInitrd(filename string, kernel []byte, initrd []byte, cmdline st
 	return nil
 }
 
-func outputLinuxKit(format string, filename string, kernel []byte, initrd []byte, cmdline string, size int, hyperkit bool) error {
+func outputLinuxKit(log Logger, format string, filename string, kernel []byte, initrd []byte, cmdline string, size int, hyperkit bool) error {
 	log.Debugf("output linuxkit generated img: %s %s size %d", format, filename, size)
 
 	tmp, err := ioutil.TempDir(filepath.Join(MobyDir, "tmp"), "moby")

--- a/cmd/moby/main.go
+++ b/cmd/moby/main.go
@@ -6,11 +6,11 @@ import (
 	"os"
 	"path/filepath"
 
-	log "github.com/Sirupsen/logrus"
+	"github.com/Sirupsen/logrus"
 )
 
 var (
-	defaultLogFormatter = &log.TextFormatter{}
+	defaultLogFormatter = &logrus.TextFormatter{}
 
 	// Version is the human-readable version
 	Version = "unknown"
@@ -27,8 +27,8 @@ var (
 type infoFormatter struct {
 }
 
-func (f *infoFormatter) Format(entry *log.Entry) ([]byte, error) {
-	if entry.Level == log.InfoLevel {
+func (f *infoFormatter) Format(entry *logrus.Entry) ([]byte, error) {
+	if entry.Level == logrus.InfoLevel {
 		return append([]byte(entry.Message), '\n'), nil
 	}
 	return defaultLogFormatter.Format(entry)
@@ -67,8 +67,11 @@ func main() {
 	flagConfigDir := flag.String("config", defaultMobyConfigDir(), "Configuration directory")
 
 	// Set up logging
-	log.SetFormatter(new(infoFormatter))
-	log.SetLevel(log.InfoLevel)
+	var log = &logrus.Logger{
+		Out:       os.Stderr,
+		Formatter: new(infoFormatter),
+		Level:     logrus.InfoLevel,
+	}
 
 	flag.Parse()
 	if *flagQuiet && *flagVerbose {
@@ -76,12 +79,12 @@ func main() {
 		os.Exit(1)
 	}
 	if *flagQuiet {
-		log.SetLevel(log.ErrorLevel)
+		log.Level = logrus.ErrorLevel
 	}
 	if *flagVerbose {
 		// Switch back to the standard formatter
-		log.SetFormatter(defaultLogFormatter)
-		log.SetLevel(log.DebugLevel)
+		log.Formatter = defaultLogFormatter
+		log.Level = logrus.DebugLevel
 	}
 
 	args := flag.Args()
@@ -104,7 +107,7 @@ func main() {
 
 	switch args[0] {
 	case "build":
-		build(args[1:])
+		build(log, args[1:])
 	case "version":
 		version()
 	case "help":

--- a/cmd/moby/trust.go
+++ b/cmd/moby/trust.go
@@ -14,7 +14,6 @@ import (
 	"strings"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/docker/distribution/reference"
 	"github.com/docker/distribution/registry/client/auth"
 	"github.com/docker/distribution/registry/client/auth/challenge"
@@ -27,7 +26,7 @@ import (
 )
 
 // TrustedReference parses an image string, and does a notary lookup to verify and retrieve the signed digest reference
-func TrustedReference(image string) (reference.Reference, error) {
+func TrustedReference(log Logger, image string) (reference.Reference, error) {
 	ref, err := reference.ParseAnyReference(image)
 	if err != nil {
 		return nil, err

--- a/cmd/moby/util.go
+++ b/cmd/moby/util.go
@@ -1,0 +1,7 @@
+package main
+
+// Logger is the interface for what library calls need in a logger
+type Logger interface {
+	Debugf(format string, args ...interface{})
+	Infof(format string, args ...interface{})
+}


### PR DESCRIPTION
Preparatory to splitting code out in a library, we do not want to
log directly in library code with our own logger, as the user may
want to do logging differently. So pass in a logger to most library
functions; this is designed so that `logrus` meets the interface.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>

Note that several libraries we use also use `logrus` directly, which is
rather poor, eg `notary`, and many `docker` libraries.