### PR TITLE
build: Add ability to override images with YAML

### DIFF
--- a/cmd/moby/build.go
+++ b/cmd/moby/build.go
@@ -201,6 +201,7 @@ func build(args []string) {
 		}
 		m = moby.AppendConfig(m, c)
 	}
+	m = moby.ApplyOverride(m)
 
 	if *buildDisableTrust {
 		log.Debugf("Disabling content trust checks for this build")

--- a/src/moby/config_test.go
+++ b/src/moby/config_test.go
@@ -73,3 +73,33 @@ func TestInvalidCap(t *testing.T) {
 		t.Error("expected error, got valid OCI config")
 	}
 }
+
+func TestApplyOverride(t *testing.T) {
+	config, err := NewConfig([]byte(`
+kernel:
+  image: "foo/bar:foo"
+init:
+- foo/bar:foo
+onboot:
+  - name: foo
+    image: foo/bar:foo
+overrides:
+  - source: foo/bar
+    substitute: foo/bar:quux
+`))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	c := ApplyOverride(config)
+
+	if c.Kernel.Image != "foo/bar:quux" {
+		t.Fatalf("No override!")
+	}
+	if c.Init[0] != "foo/bar:quux" {
+		t.Fatalf("No override1!")
+	}
+	if c.Onboot[0].Image != "foo/bar:quux" {
+		t.Fatalf("No override2!")
+	}
+}

--- a/src/moby/schema.go
+++ b/src/moby/schema.go
@@ -100,6 +100,17 @@ var schema = string(`
     "images": {
         "type": "array",
         "items": { "$ref": "#/definitions/image" }
+    },
+    "override" : {
+        "type": "object",
+        "properties": {
+            "destination": { "type": "string" },
+            "source": { "type": "string" }
+        }
+    },
+    "overrides": {
+        "type": "array",
+	"items": { "$ref": "#/definitions/override" }
     }
   },
   "properties": {
@@ -108,7 +119,8 @@ var schema = string(`
     "onboot": { "$ref": "#/definitions/images" },
     "services": { "$ref": "#/definitions/images" },
     "trust": { "$ref": "#/definitions/trust" },
-    "files": { "$ref": "#/definitions/files" }
+    "files": { "$ref": "#/definitions/files" },
+    "overrides": { "$ref": "#/definitions/overrides" }
   }
 }
 `)


### PR DESCRIPTION
This commit adds a schema and parsing logic for an override.yml.
This file is applied to an already parsed Moby config and will replace
all instances of the source pattern with the substitute pattern.
This allows for easy replacement of images in a config file for
development or test.

Fixes: #95

Signed-off-by: Dave Tucker <dave@dtucker.co.uk>