### PR TITLE
Add support for ambient capabilities

### DIFF
--- a/src/moby/build.go
+++ b/src/moby/build.go
@@ -414,6 +414,8 @@ func filesystem(m Moby, tw *tar.Writer) error {
 					Name:     root,
 					Typeflag: tar.TypeDir,
 					Mode:     dirMode,
+					Uid:      int(f.UID),
+					Gid:      int(f.GID),
 				}
 				err := tw.WriteHeader(hdr)
 				if err != nil {
@@ -423,36 +425,30 @@ func filesystem(m Moby, tw *tar.Writer) error {
 			}
 		}
 		addedFiles[f.Path] = true
+		hdr := &tar.Header{
+			Name: f.Path,
+			Mode: mode,
+			Uid:  int(f.UID),
+			Gid:  int(f.GID),
+		}
 		if f.Directory {
 			if f.Contents != nil {
 				return errors.New("Directory with contents not allowed")
 			}
-			hdr := &tar.Header{
-				Name:     f.Path,
-				Typeflag: tar.TypeDir,
-				Mode:     mode,
-			}
+			hdr.Typeflag = tar.TypeDir
 			err := tw.WriteHeader(hdr)
 			if err != nil {
 				return err
 			}
 		} else if f.Symlink != "" {
-			hdr := &tar.Header{
-				Name:     f.Path,
-				Typeflag: tar.TypeSymlink,
-				Mode:     mode,
-				Linkname: f.Symlink,
-			}
+			hdr.Typeflag = tar.TypeSymlink
+			hdr.Linkname = f.Symlink
 			err := tw.WriteHeader(hdr)
 			if err != nil {
 				return err
 			}
 		} else {
-			hdr := &tar.Header{
-				Name: f.Path,
-				Mode: mode,
-				Size: int64(len(contents)),
-			}
+			hdr.Size = int64(len(contents))
 			err := tw.WriteHeader(hdr)
 			if err != nil {
 				return err

--- a/src/moby/schema.go
+++ b/src/moby/schema.go
@@ -24,7 +24,9 @@ var schema = string(`
           "contents": {"type": "string"},
           "source": {"type": "string"},
           "optional": {"type": "boolean"},
-          "mode": {"type": "string"}
+          "mode": {"type": "string"},
+          "uid": {"type": "integer"},
+          "gid": {"type": "integer"}
         }
     },
     "files": {
@@ -65,6 +67,7 @@ var schema = string(`
         "name": {"type": "string"},
         "image": {"type": "string"},
         "capabilities": { "$ref": "#/definitions/strings" },
+        "ambient": { "$ref": "#/definitions/strings" },
         "mounts": { "$ref": "#/definitions/mounts" },
         "binds": { "$ref": "#/definitions/strings" },
         "tmpfs": { "$ref": "#/definitions/strings" },


### PR DESCRIPTION
Allow setting ambient capabilities, as a seperate option to the standard
ones. If you are running as a non root user you should use these.

Note that unless you add `CAP_DAC_OVERRIDE` and similar permissions you
need to be careful about file ownership. Added support to set ownership
in the `files` section to help out with this.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>