### PR TITLE
Error if there are duplicate service names

### DIFF
--- a/cmd/moby/build.go
+++ b/cmd/moby/build.go
@@ -199,7 +199,10 @@ func build(args []string) {
 		if err != nil {
 			log.Fatalf("Invalid config: %v", err)
 		}
-		m = moby.AppendConfig(m, c)
+		m, err = moby.AppendConfig(m, c)
+		if err != nil {
+			log.Fatalf("Cannot append config files: %v", err)
+		}
 	}
 
 	if *buildDisableTrust {


### PR DESCRIPTION
Continue to allow onboot to have duplicates as we do not run simultaneously
so that is ok (and we number them anyway), but services are run together
so we will get a runtime error if duplicated as this is the containerd/runc
id.

(note in future we may change to using a hash not a list for these, but `append` could
still error so we will still need a check).

cc @deitcher