### PR TITLE
If verbose then route linuxkit stdout to os.stdout

### DIFF
--- a/src/moby/linuxkit.go
+++ b/src/moby/linuxkit.go
@@ -139,6 +139,9 @@ func outputLinuxKit(format string, filename string, kernel []byte, initrd []byte
 	}
 	log.Debugf("run %s: %v", linuxkit, commandLine)
 	cmd := exec.Command(linuxkit, commandLine...)
+	if log.GetLevel() == log.DebugLevel {
+		cmd.Stdout = os.Stdout
+	}
 	cmd.Stderr = os.Stderr
 	err = cmd.Run()
 	if err != nil {


### PR DESCRIPTION
Without this it goes to /dev/null, unless it defaults to containerized mode, in
which case it is in `docker log`.

Signed-off-by: Ian Campbell <ijc@docker.com>