### PR TITLE
Makefile: Update for ease of Homebrew installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,23 +6,35 @@ default: moby
 DEPS=$(wildcard cmd/moby/*.go) Makefile
 PREFIX?=/usr/local
 
-moby: $(DEPS) lint
+GOLINT:=$(shell command -v golint 2> /dev/null)
+INEFFASSIGN:=$(shell command -v ineffassign 2> /dev/null)
+
+moby: $(DEPS)
 	go build --ldflags "-X main.GitCommit=$(GIT_COMMIT) -X main.Version=$(VERSION)" -o $@ github.com/moby/tool/cmd/moby
 
-.PHONY: lint
+.PHONY:
 lint:
+ifndef GOLINT
+	$(error "Please install golint! go get -u github.com/tool/lint")
+endif
+ifndef INEFFASSIGN
+	$(error "Please install ineffassign! go get -u github.com/gordonklaus/ineffassign")
+endif
 	# golint
 	@test -z "$(shell find . -type f -name "*.go" -not -path "./vendor/*" -not -name "*.pb.*" -exec golint {} \; | tee /dev/stderr)"
 	# gofmt
 	@test -z "$$(gofmt -s -l .| grep -v .pb. | grep -v vendor/ | tee /dev/stderr)"
+	# ineffassign
+	@test -z $(find . -type f -name "*.go" -not -path "*/vendor/*" -not -name "*.pb.*" -exec ineffassign {} \; | tee /dev/stderr)
 ifeq ($(GOOS),)
 	# govet
 	@test -z "$$(go tool vet -printf=false . 2>&1 | grep -v vendor/ | tee /dev/stderr)"
-	# go test
-	@go test github.com/moby/tool/src/moby
 endif
 
-test: moby
+test: lint moby
+	# go test
+	@go test github.com/moby/tool/src/moby
+	# test build
 	./moby build -output tar test/test.yml
 	rm moby test.tar
 

--- a/circle.yml
+++ b/circle.yml
@@ -8,6 +8,7 @@ jobs:
     steps:
       - checkout
       - run: go get github.com/golang/lint/golint
+      - run: go get github.com/gordonklaus/ineffassign
       - run: cd $GOPATH/src/github.com/moby/tool && make test
-      - run: cd $GOPATH/src/github.com/moby/tool && make clean && make GOOS=darwin
-      - run: cd $GOPATH/src/github.com/moby/tool && make clean && make GOOS=windows
+      - run: cd $GOPATH/src/github.com/moby/tool && make clean && make GOOS=darwin lint moby
+      - run: cd $GOPATH/src/github.com/moby/tool && make clean && make GOOS=windows lint moby


### PR DESCRIPTION
This removes the `lint` dependency from the moby target.
I've also added ineffassign to check ineffecutal assignments alongside
checks to ensure that both it and golint are installed before using it!

Note: [Tests](https://travis-ci.org/dave-tucker/homebrew-linuxkit/builds/253523307) in `hombrew-linuxkit`
shows many counts of `find: golint: No such file or directory` when golint isn't installed.
This could be an indication that we have a deeper issue with the golint runes.

- `make` builds `moby`
- `make test` lints, builds moby and runs the tests.
- `make lint moby` will lint and then builds moby

Signed-off-by: Dave Tucker <dave@dtucker.co.uk>