### PR TITLE
Allow specifying the kernel and tarball names, or omitting tarball

### DIFF
--- a/docs/yaml.md
+++ b/docs/yaml.md
@@ -44,6 +44,9 @@ which should contain a `kernel` file that will be booted (eg a `bzImage` for `am
 called `kernel.tar` which is a tarball that is unpacked into the root, which should usually
 contain a kernel modules directory. `cmdline` specifies the kernel command line options if required.
 
+To override the names, you can specify the kernel image name with `binary: bzImage` and the tar image
+with `tar: kernel.tar` or the empty string or `none` if you do not want to use a tarball at all.
+
 ## `init`
 
 The `init` section is a list of images that are used for the `init` system and are unpacked directly

--- a/src/moby/config.go
+++ b/src/moby/config.go
@@ -19,15 +19,20 @@ import (
 
 // Moby is the type of a Moby config file
 type Moby struct {
-	Kernel struct {
-		Image   string
-		Cmdline string
-	}
+	Kernel   KernelConfig
 	Init     []string
 	Onboot   []Image
 	Services []Image
 	Trust    TrustConfig
 	Files    []File
+}
+
+// KernelConfig is the type of the config for a kernel
+type KernelConfig struct {
+	Image   string
+	Cmdline string
+	Binary  string
+	Tar     *string
 }
 
 // TrustConfig is the type of a content trust config
@@ -167,6 +172,12 @@ func AppendConfig(m0, m1 Moby) (Moby, error) {
 	}
 	if m1.Kernel.Cmdline != "" {
 		moby.Kernel.Cmdline = m1.Kernel.Cmdline
+	}
+	if m1.Kernel.Binary != "" {
+		moby.Kernel.Binary = m1.Kernel.Binary
+	}
+	if m1.Kernel.Tar != nil {
+		moby.Kernel.Tar = m1.Kernel.Tar
 	}
 	moby.Init = append(moby.Init, m1.Init...)
 	moby.Onboot = append(moby.Onboot, m1.Onboot...)

--- a/src/moby/schema.go
+++ b/src/moby/schema.go
@@ -10,8 +10,10 @@ var schema = string(`
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "image": { "type": "string"},
-        "cmdline": { "type": "string"}
+        "image": {"type": "string"},
+        "cmdline": {"type": "string"},
+        "binary": {"type": "string"},
+        "tar": {"type": "string"}
       }
     },
     "file": {


### PR DESCRIPTION
fix #113

Use `tar: none` or `tar: ""` to omit the tarball.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>