### PR TITLE
Allow uid, gid fields to be numeric or names

### DIFF
--- a/docs/yaml.md
+++ b/docs/yaml.md
@@ -15,8 +15,8 @@ Each section adds file to the root file system. Sections may be omitted.
 
 Each container that is specified is allocated a unique `uid` and `gid` that it may use if it
 wishes to run as an isolated user (or user namespace). Anywhere you specify a `uid` or `gid`
-field you specify a string that can either be the numeric id, or if you use a name it will
-refer to the id allocated to the container with that name.
+field you specify either the numeric id, or if you use a name it will refer to the id allocated
+to the container with that name.
 
 ```
 services:

--- a/src/moby/config_test.go
+++ b/src/moby/config_test.go
@@ -81,8 +81,8 @@ func TestInvalidCap(t *testing.T) {
 func TestIdMap(t *testing.T) {
 	idMap := map[string]uint32{"test": 199}
 
-	uid := "test"
-	gid := "76"
+	var uid interface{} = "test"
+	var gid interface{} = 76
 
 	yaml := Image{
 		Name:  "test",

--- a/src/moby/schema.go
+++ b/src/moby/schema.go
@@ -27,8 +27,8 @@ var schema = string(`
           "source": {"type": "string"},
           "optional": {"type": "boolean"},
           "mode": {"type": "string"},
-          "uid": {"type": "string"},
-          "gid": {"type": "string"}
+          "uid": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
+          "gid": {"anyOf": [{"type": "string"}, {"type": "integer"}]}
         }
     },
     "files": {
@@ -97,11 +97,11 @@ var schema = string(`
         "readonly": { "type": "boolean"},
         "maskedPaths": { "$ref": "#/definitions/strings" },
         "readonlyPaths": { "$ref": "#/definitions/strings" },
-        "uid": {"type": "string"},
-        "gid": {"type": "string"},
+        "uid": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
+        "gid": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
         "additionalGids": {
             "type": "array",
-            "items": { "type": "string" }
+            "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]}
         },
         "noNewPrivileges": {"type": "boolean"},
         "hostname": {"type": "string"},


### PR DESCRIPTION
Previously I was forcing them to be strings, which is horrible. Now you
can either specify a numeric uid or the name of a service to use the
allocated id for that service.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>