### PR TITLE
trust: do not call x509.SystemCertPool as nil will use this as default

### DIFF
--- a/src/moby/trust.go
+++ b/src/moby/trust.go
@@ -194,13 +194,7 @@ func httpsTransport(caFile string) (*http.Transport, error) {
 		TLSClientConfig:     tlsConfig,
 	}
 	// Override with the system cert pool if the caFile was empty
-	if caFile == "" {
-		systemCertPool, err := x509.SystemCertPool()
-		if err != nil {
-			return nil, err
-		}
-		transport.TLSClientConfig.RootCAs = systemCertPool
-	} else {
+	if caFile != "" {
 		certPool := x509.NewCertPool()
 		pems, err := ioutil.ReadFile(caFile)
 		if err != nil {


### PR DESCRIPTION
Passing a `nil` pool will automatically use the system pool, even on Windows.  I tested locally with an empty trust cache.

Closes #119 

Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>