### PR TITLE
Add a tmp directory for each container to be used as a mount point

### DIFF
--- a/src/moby/image.go
+++ b/src/moby/image.go
@@ -189,6 +189,16 @@ func ImageBundle(path string, image string, config []byte, tw tarWriter, trust b
 	if err != nil {
 		return err
 	}
+	// add a tmp directory to be used as a mount point if needed
+	hdr = &tar.Header{
+		Name:     path + "/" + "tmp",
+		Mode:     0755,
+		Typeflag: tar.TypeDir,
+	}
+	err = tw.WriteHeader(hdr)
+	if err != nil {
+		return err
+	}
 
 	return nil
 }


### PR DESCRIPTION
This is to clean up how we do writeable containers in LinuxKit.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>