### PR TITLE
Rework setup of container for read only/read write

### DIFF
--- a/src/moby/build.go
+++ b/src/moby/build.go
@@ -186,7 +186,8 @@ func Build(m Moby, w io.Writer, pull bool, tp string) error {
 		}
 		so := fmt.Sprintf("%03d", i)
 		path := "containers/onboot/" + so + "-" + image.Name
-		err = ImageBundle(path, image.Image, config, iw, useTrust, pull)
+		readonly := image.Readonly != nil && *image.Readonly
+		err = ImageBundle(path, image.Image, config, iw, useTrust, pull, readonly)
 		if err != nil {
 			return fmt.Errorf("Failed to extract root filesystem for %s: %v", image.Image, err)
 		}
@@ -204,7 +205,8 @@ func Build(m Moby, w io.Writer, pull bool, tp string) error {
 		}
 		so := fmt.Sprintf("%03d", i)
 		path := "containers/onshutdown/" + so + "-" + image.Name
-		err = ImageBundle(path, image.Image, config, iw, useTrust, pull)
+		readonly := image.Readonly != nil && *image.Readonly
+		err = ImageBundle(path, image.Image, config, iw, useTrust, pull, readonly)
 		if err != nil {
 			return fmt.Errorf("Failed to extract root filesystem for %s: %v", image.Image, err)
 		}
@@ -221,7 +223,8 @@ func Build(m Moby, w io.Writer, pull bool, tp string) error {
 			return fmt.Errorf("Failed to create config.json for %s: %v", image.Image, err)
 		}
 		path := "containers/services/" + image.Name
-		err = ImageBundle(path, image.Image, config, iw, useTrust, pull)
+		readonly := image.Readonly != nil && *image.Readonly
+		err = ImageBundle(path, image.Image, config, iw, useTrust, pull, readonly)
 		if err != nil {
 			return fmt.Errorf("Failed to extract root filesystem for %s: %v", image.Image, err)
 		}


### PR DESCRIPTION
To work with truly immutable filesystems, rather than ones
we sneakily remount `rw`, we are going to use overlay for
writeable containers. To leave the final mount as `rootfs`,
in the writeable case we make a new `lower` path for the read
only filesystem, and leave `rootfs` as a mount point for an
overlay, with the writable layer and workdir mounted as a tmpfs
on `tmp`.

See https://github.com/linuxkit/linuxkit/issues/2288

Signed-off-by: Justin Cormack <justin.cormack@docker.com>