### PR TITLE
Fix hardlinks in tar output

### DIFF
--- a/src/moby/image.go
+++ b/src/moby/image.go
@@ -172,6 +172,10 @@ func ImageTar(image, prefix string, tw tarWriter, trust bool, pull bool, resolv 
 		} else {
 			log.Debugf("image tar: %s %s add %s", image, prefix, hdr.Name)
 			hdr.Name = prefix + hdr.Name
+			if hdr.Typeflag == tar.TypeLink {
+				// hard links are referenced by full path so need to be adjusted
+				hdr.Linkname = prefix + hdr.Linkname
+			}
 			if err := tw.WriteHeader(hdr); err != nil {
 				return err
 			}


### PR DESCRIPTION
When we converted these to cpio we were not noticing that they
were invalid as they had incorrect paths as we converted the
path to a symlink anyway. Only the busybox images have hard links
in, the Alpine ones are symlinks anyway, which is why it was
less visible too.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>