### PR TITLE
Add support for runtime configuration

### DIFF
--- a/src/moby/config_test.go
+++ b/src/moby/config_test.go
@@ -44,7 +44,7 @@ func TestOverrides(t *testing.T) {
 
 	inspect := setupInspect(t, label)
 
-	oci, err := ConfigInspectToOCI(yaml, inspect, idMap)
+	oci, _, err := ConfigInspectToOCI(yaml, inspect, idMap)
 	if err != nil {
 		t.Error(err)
 	}
@@ -72,7 +72,7 @@ func TestInvalidCap(t *testing.T) {
 
 	inspect := setupInspect(t, label)
 
-	_, err := ConfigInspectToOCI(yaml, inspect, idMap)
+	_, _, err := ConfigInspectToOCI(yaml, inspect, idMap)
 	if err == nil {
 		t.Error("expected error, got valid OCI config")
 	}
@@ -95,7 +95,7 @@ func TestIdMap(t *testing.T) {
 
 	inspect := setupInspect(t, label)
 
-	oci, err := ConfigInspectToOCI(yaml, inspect, idMap)
+	oci, _, err := ConfigInspectToOCI(yaml, inspect, idMap)
 	if err != nil {
 		t.Error(err)
 	}

--- a/src/moby/schema.go
+++ b/src/moby/schema.go
@@ -208,6 +208,42 @@ var schema = string(`
         "network": {"$ref": "#/definitions/network"}
       }
     },
+    "interfaces": {
+      "type": "array",
+      "items": {"$ref": "#/definitions/interface"}
+    },
+    "interface": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {"type": "string"},
+        "add": {"type": "string"},
+        "peer": {"type": "string"},
+        "createInRoot": {"type": "boolean"}
+      }
+    },
+    "namespaces": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "cgroup": {"type": "string"},
+        "ipc": {"type": "string"},
+        "mnt": {"type": "string"},
+        "net": {"type": "string"},
+        "pid": {"type": "string"},
+        "user": {"type": "string"},
+        "uts": {"type": "string"}
+      }
+    },
+    "runtime": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "mkdir": {"$ref": "#/definitions/strings"},
+        "interfaces": {"$ref": "#/definitions/interfaces"},
+        "bindNS": {"$ref": "#/definitions/namespaces"}
+      }
+    },
     "image": {
       "type": "object",
       "additionalProperties": false,
@@ -249,7 +285,8 @@ var schema = string(`
         },
         "rlimits": { "$ref": "#/definitions/strings" },
         "uidMappings": { "$ref": "#/definitions/idmappings" },
-        "gidMappings": { "$ref": "#/definitions/idmappings" }
+        "gidMappings": { "$ref": "#/definitions/idmappings" },
+        "runtime": {"$ref": "#/definitions/runtime"}
       }
     },
     "images": {


### PR DESCRIPTION
This adds a `runtime` section in the config that can be used
to move network interfaces into a container, create directories,
and bind mount container namespaces into the filesystem.

See also https://github.com/linuxkit/linuxkit/pull/2413

Signed-off-by: Justin Cormack <justin.cormack@docker.com>