### PR TITLE
Add support for mount in runtime config

### DIFF
--- a/docs/yaml.md
+++ b/docs/yaml.md
@@ -183,6 +183,8 @@ permissions issues in use.
 
 In addition to the parts of the specification above used to generate the OCI spec, there is a `runtime` section in the image specification
 which specifies some actions to take place when the container is being started.
+- `mounts` takes a list of mount specifications (`source`, `destination`, `type`, `options`) and mounts them in the root namespace before the container is created. It will
+  try to make any missing destination directories.
 - `mkdir` takes a list of directories to create at runtime, in the root mount namespace. These are created before the container is started, so they can be used to create
   directories for bind mounts, for example in `/tmp` or `/run` which would otherwise be empty.
 - `interface` defines a list of actions to perform on a network interface:

--- a/src/moby/build.go
+++ b/src/moby/build.go
@@ -131,13 +131,9 @@ func outputImage(image Image, section string, prefix string, m Moby, idMap map[s
 	if err != nil {
 		return fmt.Errorf("Failed to create config for %s: %v", image.Image, err)
 	}
-	runtimeConfig, err := json.MarshalIndent(runtime, "", "    ")
-	if err != nil {
-		return fmt.Errorf("Failed to create runtime config for %s: %v", image.Image, err)
-	}
 	path := path.Join("containers", section, prefix+image.Name)
 	readonly := oci.Root.Readonly
-	err = ImageBundle(path, image.Image, config, runtimeConfig, iw, useTrust, pull, readonly)
+	err = ImageBundle(path, image.Image, config, runtime, iw, useTrust, pull, readonly)
 	if err != nil {
 		return fmt.Errorf("Failed to extract root filesystem for %s: %v", image.Image, err)
 	}

--- a/src/moby/build.go
+++ b/src/moby/build.go
@@ -120,7 +120,7 @@ func enforceContentTrust(fullImageName string, config *TrustConfig) bool {
 	return false
 }
 
-func outputImage(image Image, section string, prefix string, m Moby, idMap map[string]uint32, pull bool, iw *tar.Writer) error {
+func outputImage(image Image, section string, prefix string, m Moby, idMap map[string]uint32, dupMap map[string]string, pull bool, iw *tar.Writer) error {
 	log.Infof("  Create OCI config for %s", image.Image)
 	useTrust := enforceContentTrust(image.Image, &m.Trust)
 	oci, runtime, err := ConfigToOCI(image, useTrust, idMap)
@@ -133,7 +133,7 @@ func outputImage(image Image, section string, prefix string, m Moby, idMap map[s
 	}
 	path := path.Join("containers", section, prefix+image.Name)
 	readonly := oci.Root.Readonly
-	err = ImageBundle(path, image.Image, config, runtime, iw, useTrust, pull, readonly)
+	err = ImageBundle(path, image.Image, config, runtime, iw, useTrust, pull, readonly, dupMap)
 	if err != nil {
 		return fmt.Errorf("Failed to extract root filesystem for %s: %v", image.Image, err)
 	}
@@ -167,6 +167,9 @@ func Build(m Moby, w io.Writer, pull bool, tp string) error {
 		id++
 	}
 
+	// deduplicate containers with the same image
+	dupMap := map[string]string{}
+
 	if m.Kernel.Image != "" {
 		// get kernel and initrd tarball from container
 		log.Infof("Extract kernel image: %s", m.Kernel.Image)
@@ -198,7 +201,7 @@ func Build(m Moby, w io.Writer, pull bool, tp string) error {
 	}
 	for i, image := range m.Onboot {
 		so := fmt.Sprintf("%03d", i)
-		if err := outputImage(image, "onboot", so+"-", m, idMap, pull, iw); err != nil {
+		if err := outputImage(image, "onboot", so+"-", m, idMap, dupMap, pull, iw); err != nil {
 			return err
 		}
 	}
@@ -208,7 +211,7 @@ func Build(m Moby, w io.Writer, pull bool, tp string) error {
 	}
 	for i, image := range m.Onshutdown {
 		so := fmt.Sprintf("%03d", i)
-		if err := outputImage(image, "onshutdown", so+"-", m, idMap, pull, iw); err != nil {
+		if err := outputImage(image, "onshutdown", so+"-", m, idMap, dupMap, pull, iw); err != nil {
 			return err
 		}
 	}
@@ -217,7 +220,7 @@ func Build(m Moby, w io.Writer, pull bool, tp string) error {
 		log.Infof("Add service containers:")
 	}
 	for _, image := range m.Services {
-		if err := outputImage(image, "services", "", m, idMap, pull, iw); err != nil {
+		if err := outputImage(image, "services", "", m, idMap, dupMap, pull, iw); err != nil {
 			return err
 		}
 	}

--- a/src/moby/config.go
+++ b/src/moby/config.go
@@ -93,9 +93,10 @@ type Image struct {
 
 // Runtime is the type of config processed at runtime, not used to build the OCI spec
 type Runtime struct {
-	Mkdir      []string    `yaml:"mkdir" json:"mkdir,omitempty"`
-	Interfaces []Interface `yaml:"interfaces" json:"interfaces,omitempty"`
-	BindNS     *Namespaces `yaml:"bindNS" json:"bindNS,omitempty"`
+	Mounts     []specs.Mount `yaml:"mounts" json:"mounts,omitempty"`
+	Mkdir      []string      `yaml:"mkdir" json:"mkdir,omitempty"`
+	Interfaces []Interface   `yaml:"interfaces" json:"interfaces,omitempty"`
+	BindNS     Namespaces    `yaml:"bindNS" json:"bindNS,omitempty"`
 }
 
 // Namespaces is the type for configuring paths to bind namespaces
@@ -727,7 +728,6 @@ func ConfigInspectToOCI(yaml Image, inspect types.ImageInspect, idMap map[string
 	sort.Sort(mountList)
 
 	namespaces := []specs.LinuxNamespace{}
-	// to attach to an existing namespace, easiest to bind mount with nsfs in a system container
 
 	// net, ipc, and uts namespaces: default to not creating a new namespace (usually host namespace)
 	netNS := assignStringEmpty3("root", label.Net, yaml.Net)

--- a/src/moby/schema.go
+++ b/src/moby/schema.go
@@ -239,6 +239,7 @@ var schema = string(`
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "mounts": {"$ref": "#/definitions/mounts"},
         "mkdir": {"$ref": "#/definitions/strings"},
         "interfaces": {"$ref": "#/definitions/interfaces"},
         "bindNS": {"$ref": "#/definitions/namespaces"}


### PR DESCRIPTION
This could be used in LinuxKit now, as there are some examples, eg
https://github.com/linuxkit/linuxkit/blob/master/blueprints/docker-for-mac/base.yml#L33
which are creating containers to do a mount.

This now also uses these to generate the mounts needed for writeable containers, and also automatically de-dups containers that share the same image by using the same mount as the source.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>