### PR TITLE
Rename "output" to "format"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ test: lint moby
 	# go test
 	@go test github.com/moby/tool/src/moby
 	# test build
-	./moby build -output tar test/test.yml
+	./moby build -format tar test/test.yml
 	rm moby test.tar
 
 .PHONY: install

--- a/examples/README.md
+++ b/examples/README.md
@@ -13,10 +13,10 @@ then start the `onboot` and `service` containers. The example below shows how yo
 can run `nginx` on either of these base configs.
 
 ```
-moby build -output docker -o - docker.yml nginx.yml | docker build -t dockertest -
+moby build -format docker -o - docker.yml nginx.yml | docker build -t dockertest -
 docker run -d -p 80:80 --privileged dockertest
 
-moby build -output kernel+initrd linuxkit.yml nginx.yml
+moby build -format kernel+initrd linuxkit.yml nginx.yml
 linuxkit run nginx
 ```
 

--- a/src/moby/output.go
+++ b/src/moby/output.go
@@ -132,33 +132,33 @@ func ensurePrereq(out string) error {
 	return err
 }
 
-// ValidateOutputs checks if the output type is known
-func ValidateOutputs(out []string) error {
-	log.Debugf("validating output: %v", out)
+// ValidateFormats checks if the format type is known
+func ValidateFormats(formats []string) error {
+	log.Debugf("validating output: %v", formats)
 
-	for _, o := range out {
+	for _, o := range formats {
 		f := outFuns[o]
 		if f == nil {
-			return fmt.Errorf("Unknown output type %s", o)
+			return fmt.Errorf("Unknown format type %s", o)
 		}
 		err := ensurePrereq(o)
 		if err != nil {
-			return fmt.Errorf("Failed to set up output type %s: %v", o, err)
+			return fmt.Errorf("Failed to set up format type %s: %v", o, err)
 		}
 	}
 
 	return nil
 }
 
-// Outputs generates all the specified output formats
-func Outputs(base string, image []byte, out []string, size int, hyperkit bool) error {
-	log.Debugf("output: %v %s", out, base)
+// Formats generates all the specified output formats
+func Formats(base string, image []byte, formats []string, size int, hyperkit bool) error {
+	log.Debugf("format: %v %s", formats, base)
 
-	err := ValidateOutputs(out)
+	err := ValidateFormats(formats)
 	if err != nil {
 		return err
 	}
-	for _, o := range out {
+	for _, o := range formats {
 		f := outFuns[o]
 		err := f(base, image, size, hyperkit)
 		if err != nil {


### PR DESCRIPTION
This was confusing as there is an option to output to a file as well.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>

cc @deitch I think you suggested this...