### PR TITLE
Couple of minor updates to metadata file output

### DIFF
--- a/docs/yaml.md
+++ b/docs/yaml.md
@@ -110,7 +110,7 @@ supported here is `"yaml"` which will output the yaml used to generate the image
 file:
 ```
   - path: etc/linuxkit.yml
-    metadata:yaml
+    metadata: yaml
 ```
 
 ## `trust`

--- a/src/moby/build.go
+++ b/src/moby/build.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 
 	log "github.com/Sirupsen/logrus"
+	"gopkg.in/yaml.v2"
 )
 
 const defaultNameForStdin = "moby"
@@ -389,8 +390,10 @@ func tarAppend(iw *tar.Writer, tr *tar.Reader) error {
 // this allows inserting metadata into a file in the image
 func metadata(m Moby, md string) ([]byte, error) {
 	switch md {
-	case "yaml":
+	case "json":
 		return json.MarshalIndent(m, "", "    ")
+	case "yaml":
+		return yaml.Marshal(m)
 	default:
 		return []byte{}, fmt.Errorf("Unsupported metadata type: %s", md)
 	}


### PR DESCRIPTION
- correct the syntax of the documented example
- make it really produce yaml (and add the previous mode as "json" since that is what it was producing).