### PR TITLE
Remove the hyperkit option

### DIFF
--- a/cmd/moby/build.go
+++ b/cmd/moby/build.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strconv"
 	"strings"
 
@@ -72,7 +71,6 @@ func build(args []string) {
 	buildSize := buildCmd.String("size", "1024M", "Size for output image, if supported and fixed size")
 	buildPull := buildCmd.Bool("pull", false, "Always pull images")
 	buildDisableTrust := buildCmd.Bool("disable-content-trust", false, "Skip image trust verification specified in trust section of config (default false)")
-	buildHyperkit := buildCmd.Bool("hyperkit", runtime.GOOS == "darwin", "Use hyperkit for LinuxKit based builds where possible")
 	buildCmd.Var(&buildFormats, "format", "Formats to create [ "+strings.Join(outputTypes, " ")+" ]")
 
 	if err := buildCmd.Parse(args); err != nil {
@@ -231,7 +229,7 @@ func build(args []string) {
 	if outputFile == nil {
 		image := buf.Bytes()
 		log.Infof("Create outputs:")
-		err = moby.Formats(filepath.Join(*buildDir, name), image, buildFormats, size, *buildHyperkit)
+		err = moby.Formats(filepath.Join(*buildDir, name), image, buildFormats, size)
 		if err != nil {
 			log.Fatalf("Error writing outputs: %v", err)
 		}

--- a/src/moby/linuxkit.go
+++ b/src/moby/linuxkit.go
@@ -89,7 +89,7 @@ func writeKernelInitrd(filename string, kernel []byte, initrd []byte, cmdline st
 	return nil
 }
 
-func outputLinuxKit(format string, filename string, kernel []byte, initrd []byte, cmdline string, size int, hyperkit bool) error {
+func outputLinuxKit(format string, filename string, kernel []byte, initrd []byte, cmdline string, size int) error {
 	log.Debugf("output linuxkit generated img: %s %s size %d", format, filename, size)
 
 	tmp, err := ioutil.TempDir(filepath.Join(MobyDir, "tmp"), "moby")
@@ -128,14 +128,6 @@ func outputLinuxKit(format string, filename string, kernel []byte, initrd []byte
 		return fmt.Errorf("Cannot find linuxkit executable, needed to build %s output type: %v", format, err)
 	}
 	commandLine := []string{"-q", "run", "qemu", "-disk", fmt.Sprintf("%s,size=%s,format=%s", filename, sizeString, format), "-disk", fmt.Sprintf("%s,format=raw", tardisk), "-kernel", imageFilename("mkimage")}
-	if hyperkit && format == "raw" {
-		state, err := ioutil.TempDir("", "s")
-		if err != nil {
-			return err
-		}
-		defer os.RemoveAll(state)
-		commandLine = []string{"-q", "run", "hyperkit", "-state", state, "-disk", fmt.Sprintf("%s,size=%s,format=%s", filename, sizeString, format), "-disk", fmt.Sprintf("%s,format=raw", tardisk), imageFilename("mkimage")}
-	}
 	log.Debugf("run %s: %v", linuxkit, commandLine)
 	cmd := exec.Command(linuxkit, commandLine...)
 	cmd.Stderr = os.Stderr

--- a/src/moby/output.go
+++ b/src/moby/output.go
@@ -20,8 +20,8 @@ const (
 	dynamicvhd = "linuxkit/mkimage-dynamic-vhd:a652b15c281499ecefa6a7a47d0f9c56d70ab208@sha256:10e2a9179d48934c864639df895a6efdee34c2865eb574934398209625b297ff"
 )
 
-var outFuns = map[string]func(string, []byte, int, bool) error{
-	"kernel+initrd": func(base string, image []byte, size int, hyperkit bool) error {
+var outFuns = map[string]func(string, []byte, int) error{
+	"kernel+initrd": func(base string, image []byte, size int) error {
 		kernel, initrd, cmdline, err := tarToInitrd(image)
 		if err != nil {
 			return fmt.Errorf("Error converting to initrd: %v", err)
@@ -32,34 +32,34 @@ var outFuns = map[string]func(string, []byte, int, bool) error{
 		}
 		return nil
 	},
-	"iso-bios": func(base string, image []byte, size int, hyperkit bool) error {
+	"iso-bios": func(base string, image []byte, size int) error {
 		err := outputIso(bios, base+".iso", image)
 		if err != nil {
 			return fmt.Errorf("Error writing iso-bios output: %v", err)
 		}
 		return nil
 	},
-	"iso-efi": func(base string, image []byte, size int, hyperkit bool) error {
+	"iso-efi": func(base string, image []byte, size int) error {
 		err := outputIso(efi, base+"-efi.iso", image)
 		if err != nil {
 			return fmt.Errorf("Error writing iso-efi output: %v", err)
 		}
 		return nil
 	},
-	"raw": func(base string, image []byte, size int, hyperkit bool) error {
+	"raw": func(base string, image []byte, size int) error {
 		filename := base + ".raw"
 		log.Infof("  %s", filename)
 		kernel, initrd, cmdline, err := tarToInitrd(image)
 		if err != nil {
 			return fmt.Errorf("Error converting to initrd: %v", err)
 		}
-		err = outputLinuxKit("raw", filename, kernel, initrd, cmdline, size, hyperkit)
+		err = outputLinuxKit("raw", filename, kernel, initrd, cmdline, size)
 		if err != nil {
 			return fmt.Errorf("Error writing raw output: %v", err)
 		}
 		return nil
 	},
-	"gcp": func(base string, image []byte, size int, hyperkit bool) error {
+	"gcp": func(base string, image []byte, size int) error {
 		kernel, initrd, cmdline, err := tarToInitrd(image)
 		if err != nil {
 			return fmt.Errorf("Error converting to initrd: %v", err)
@@ -70,20 +70,20 @@ var outFuns = map[string]func(string, []byte, int, bool) error{
 		}
 		return nil
 	},
-	"qcow2": func(base string, image []byte, size int, hyperkit bool) error {
+	"qcow2": func(base string, image []byte, size int) error {
 		filename := base + ".qcow2"
 		log.Infof("  %s", filename)
 		kernel, initrd, cmdline, err := tarToInitrd(image)
 		if err != nil {
 			return fmt.Errorf("Error converting to initrd: %v", err)
 		}
-		err = outputLinuxKit("qcow2", filename, kernel, initrd, cmdline, size, hyperkit)
+		err = outputLinuxKit("qcow2", filename, kernel, initrd, cmdline, size)
 		if err != nil {
 			return fmt.Errorf("Error writing qcow2 output: %v", err)
 		}
 		return nil
 	},
-	"vhd": func(base string, image []byte, size int, hyperkit bool) error {
+	"vhd": func(base string, image []byte, size int) error {
 		kernel, initrd, cmdline, err := tarToInitrd(image)
 		if err != nil {
 			return fmt.Errorf("Error converting to initrd: %v", err)
@@ -94,7 +94,7 @@ var outFuns = map[string]func(string, []byte, int, bool) error{
 		}
 		return nil
 	},
-	"dynamic-vhd": func(base string, image []byte, size int, hyperkit bool) error {
+	"dynamic-vhd": func(base string, image []byte, size int) error {
 		kernel, initrd, cmdline, err := tarToInitrd(image)
 		if err != nil {
 			return fmt.Errorf("Error converting to initrd: %v", err)
@@ -105,7 +105,7 @@ var outFuns = map[string]func(string, []byte, int, bool) error{
 		}
 		return nil
 	},
-	"vmdk": func(base string, image []byte, size int, hyperkit bool) error {
+	"vmdk": func(base string, image []byte, size int) error {
 		kernel, initrd, cmdline, err := tarToInitrd(image)
 		if err != nil {
 			return fmt.Errorf("Error converting to initrd: %v", err)
@@ -151,7 +151,7 @@ func ValidateFormats(formats []string) error {
 }
 
 // Formats generates all the specified output formats
-func Formats(base string, image []byte, formats []string, size int, hyperkit bool) error {
+func Formats(base string, image []byte, formats []string, size int) error {
 	log.Debugf("format: %v %s", formats, base)
 
 	err := ValidateFormats(formats)
@@ -160,7 +160,7 @@ func Formats(base string, image []byte, formats []string, size int, hyperkit boo
 	}
 	for _, o := range formats {
 		f := outFuns[o]
-		err := f(base, image, size, hyperkit)
+		err := f(base, image, size)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
We are going to phase out the LinuxKit build option, in favour of keeping Docker
or a native Linux build option for CI use cases, as it is faster. So the
hyperkit option that only worked in one very limited use case is not needed.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>