### PR TITLE
Add back init image processing logging

### DIFF
--- a/src/moby/build.go
+++ b/src/moby/build.go
@@ -190,6 +190,7 @@ func Build(m Moby, w io.Writer, pull bool, tp string) error {
 		log.Infof("Add init containers:")
 	}
 	for _, ii := range m.initRefs {
+		log.Infof("Process init image: %s", ii)
 		err := ImageTar(ii, "", iw, enforceContentTrust(ii.String(), &m.Trust), pull, resolvconfSymlink)
 		if err != nil {
 			return fmt.Errorf("Failed to build init tarball from %s: %v", ii, err)


### PR DESCRIPTION
Since #159 there is no more logging during the processing of init images. This PR adds it back :)