### PR TITLE
Add `user-binds` to image config

### DIFF
--- a/src/moby/config.go
+++ b/src/moby/config.go
@@ -68,6 +68,7 @@ type Image struct {
 	Ambient           *[]string               `yaml:"ambient" json:"ambient,omitempty"`
 	Mounts            *[]specs.Mount          `yaml:"mounts" json:"mounts,omitempty"`
 	Binds             *[]string               `yaml:"binds" json:"binds,omitempty"`
+	UserBinds         *[]string               `yaml:"user-binds" json:"user-binds,omitempty"`
 	Tmpfs             *[]string               `yaml:"tmpfs" json:"tmpfs,omitempty"`
 	Command           *[]string               `yaml:"command" json:"command,omitempty"`
 	Env               *[]string               `yaml:"env" json:"env,omitempty"`
@@ -300,6 +301,14 @@ func AppendConfig(m0, m1 Moby) (Moby, error) {
 	}
 
 	return moby, nil
+}
+
+// AppendStringSlicePointer appends a possibly nil string slice pointer to a string slice
+func AppendStringSlicePointer(s []string, p *[]string) []string {
+	if p == nil {
+		return s
+	}
+	return append(s, *p...)
 }
 
 // NewImage validates an parses yaml or json for a Image
@@ -747,6 +756,10 @@ func ConfigInspectToOCI(yaml *Image, inspect types.ImageInspect, idMap map[strin
 		}
 	}
 
+	if label.UserBinds != nil && len(*label.UserBinds) != 0 {
+		return oci, runtime, fmt.Errorf("user-binds in image label is not allowed")
+	}
+
 	// command, env and cwd can be taken from image, as they are commonly specified in Dockerfile
 
 	// TODO we could handle entrypoint and cmd independently more like Docker
@@ -794,7 +807,7 @@ func ConfigInspectToOCI(yaml *Image, inspect types.ImageInspect, idMap map[strin
 		}
 		mounts[dest] = specs.Mount{Destination: dest, Type: "tmpfs", Source: "tmpfs", Options: opts}
 	}
-	for _, b := range assignStrings(label.Binds, yaml.Binds) {
+	for _, b := range AppendStringSlicePointer(assignStrings(label.Binds, yaml.Binds), yaml.UserBinds) {
 		parts := strings.Split(b, ":")
 		if len(parts) < 2 {
 			return oci, runtime, fmt.Errorf("Cannot parse bind, missing ':': %s", b)

--- a/src/moby/schema.go
+++ b/src/moby/schema.go
@@ -256,6 +256,7 @@ var schema = string(`
         "ambient": { "$ref": "#/definitions/strings" },
         "mounts": { "$ref": "#/definitions/mounts" },
         "binds": { "$ref": "#/definitions/strings" },
+        "user-binds": { "$ref": "#/definitions/strings" },
         "tmpfs": { "$ref": "#/definitions/strings" },
         "command": { "$ref": "#/definitions/strings" },
         "env": { "$ref": "#/definitions/strings" },


### PR DESCRIPTION
These extra binds are appended (unconditionally) to the label mounts. Setting
`user-binds` in an image label is forbidden, i.e. they are only allowed in
assemblies.

This allows users to augment the set of binds specified in the image label with
some local ones. Previously to do this one would have to duplicate all the
binds from the image in the assemlby, which is error prone and likely to get
out of date.

There may be other fields where such a distinction would be valuable, this is
intended to validate the concept.

Signed-off-by: Ian Campbell <ijc@docker.com>