### PR TITLE
Add raw file formats, rename raw to aws and qcow2 to qcow2-bios

### DIFF
--- a/src/moby/output.go
+++ b/src/moby/output.go
@@ -13,8 +13,10 @@ import (
 )
 
 const (
-	bios       = "linuxkit/mkimage-iso-bios:165b051322578cb0c2a4f16253b20f7d2797a502"
-	efi        = "linuxkit/mkimage-iso-efi:dc12bc6827f84334b02d1c70599acf80b840c126"
+	isoBios    = "linuxkit/mkimage-iso-bios:165b051322578cb0c2a4f16253b20f7d2797a502"
+	isoEfi     = "linuxkit/mkimage-iso-efi:dc12bc6827f84334b02d1c70599acf80b840c126"
+	rawBios    = "linuxkit/mkimage-raw-bios:58e4f6cc12c9b34d7aaeba323c7bca0b30ba43cb"
+	rawEfi     = "linuxkit/mkimage-raw-efi:fcd94e494396e314a9d24be7e1379ccc8eb380e0"
 	gcp        = "linuxkit/mkimage-gcp:d1883809d212ce048f60beb0308a4d2b14c256af"
 	vhd        = "linuxkit/mkimage-vhd:2a31f2bc91c1d247160570bd17868075e6c0009a"
 	vmdk       = "linuxkit/mkimage-vmdk:df02a4fabd87a82209fbbacebde58c4440d2daf0"
@@ -45,20 +47,36 @@ var outFuns = map[string]func(string, []byte, int) error{
 		return nil
 	},
 	"iso-bios": func(base string, image []byte, size int) error {
-		err := outputIso(bios, base+".iso", image)
+		err := outputIso(isoBios, base+".iso", image)
 		if err != nil {
 			return fmt.Errorf("Error writing iso-bios output: %v", err)
 		}
 		return nil
 	},
 	"iso-efi": func(base string, image []byte, size int) error {
-		err := outputIso(efi, base+"-efi.iso", image)
+		err := outputIso(isoEfi, base+"-efi.iso", image)
 		if err != nil {
 			return fmt.Errorf("Error writing iso-efi output: %v", err)
 		}
 		return nil
 	},
-	"raw": func(base string, image []byte, size int) error {
+	"raw-bios": func(base string, image []byte, size int) error {
+		kernel, initrd, cmdline, err := tarToInitrd(image)
+		err = outputImg(rawBios, base+"-bios.img", kernel, initrd, cmdline)
+		if err != nil {
+			return fmt.Errorf("Error writing raw-bios output: %v", err)
+		}
+		return nil
+	},
+	"raw-efi": func(base string, image []byte, size int) error {
+		kernel, initrd, cmdline, err := tarToInitrd(image)
+		err = outputImg(rawEfi, base+"-efi.img", kernel, initrd, cmdline)
+		if err != nil {
+			return fmt.Errorf("Error writing raw-efi output: %v", err)
+		}
+		return nil
+	},
+	"aws": func(base string, image []byte, size int) error {
 		filename := base + ".raw"
 		log.Infof("  %s", filename)
 		kernel, initrd, cmdline, err := tarToInitrd(image)
@@ -82,7 +100,7 @@ var outFuns = map[string]func(string, []byte, int) error{
 		}
 		return nil
 	},
-	"qcow2": func(base string, image []byte, size int) error {
+	"qcow2-bios": func(base string, image []byte, size int) error {
 		filename := base + ".qcow2"
 		log.Infof("  %s", filename)
 		kernel, initrd, cmdline, err := tarToInitrd(image)


### PR DESCRIPTION
Signed-off-by: Avi Deitcher <avi@deitcher.net>

this PR does the following:

* Add new output format: `raw-efi` - amd64 and arm64
* Add new output format `raw-bios` - amd64 only (BIOS doesn't exist on arm)
* Rename output format `raw` to `aws` 
* Rename output format `qcow2` to `qcow2-bios`

Reasonings as follows:

#### raw-efi
Didn't exist until now. Completes the [merged raw-efi linuxkit PR](https://github.com/linuxkit/linuxkit/pull/2540)

#### raw-bios
The existing "raw" format really created a large image (1GB) to comply with AWS requirements. It also was bios only, and therefore the name was confusing. It also required launching linuxkit and building in a VM.

This new format is minimal, per linuxkit philosophy, has a clear name, and builds using `docker run`. There is an intent to merge the functionality into moby directly in the future without requiring any external exec (docker or linuxkit). Eventually.

Completes the [merged raw-bios linuxkit PR](https://github.com/linuxkit/linuxkit/pull/2558)

#### aws
Keeps the existing AWS-compatibile format, but gives it the `-format aws` instead of `-format raw`. This makes it less confusing, and keeps it in line with the other output format names.

#### qcow2
The existing qcow2 output format is BIOS only. An EFI one could be done (and will), but at the least, let's make the name clear. 


**Note:** This remains `[WIP]` as testing is incomplete. Will remove `[WIP]` flag and comment here when testing is done.

/cc @justincormack 