### PR TITLE
Prob: Files section does not work for /var dir

### DIFF
--- a/docs/yaml.md
+++ b/docs/yaml.md
@@ -113,6 +113,8 @@ file:
     metadata: yaml
 ```
 
+Because a `tmpfs` is mounted onto `/var`, `/run`, and `/tmp` by default, the `tmpfs` mounts will shadow anything specified in `files` section for those directories.
+
 ## `trust`
 
 The `trust` section specifies which build components are to be cryptographically verified with


### PR DESCRIPTION
Solv: Updated documentation to point out limits of
files section regarding /var, /run, and /tmp dirs.

This attempts to update documentation due to https://github.com/linuxkit/linuxkit/issues/2711.