### PR TITLE
Tweak circleci config to try and fix artifact upload

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
       image: circleci/classic:201710-02
     environment:
       GOPATH: /home/circleci/.go_workspace
-    working_directory: $GOPATH/src/github.com/moby/tool
+    working_directory: /home/circleci/.go_workspace/src/github.com/moby/tool
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,7 @@ jobs:
             make GOOS=darwin  dist/moby-darwin
             make GOOS=windows dist/moby-windows
             make GOOS=linux   dist/moby-linux
+            cd dist && sha256sum moby-* > SHA256SUM
       - store_artifacts:
           path: ./dist
           destination: .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,3 +35,4 @@ jobs:
             make GOOS=linux   dist/moby-linux
       - store_artifacts:
           path: ./dist
+          destination: .


### PR DESCRIPTION
Signed-off-by: Ian Campbell <ijc@docker.com>

I don't know why but the current arrangement seems to not be working, at least the two most recent master builds seem to lack them:
https://circleci.com/gh/moby/tool/292#artifacts/containers/0
https://circleci.com/gh/moby/tool/289#artifacts/containers/0

I can't see anything wrong with the existing file, but try perturbing it...