### PR TITLE
Fix docker format build example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -13,7 +13,7 @@ then start the `onboot` and `service` containers. The example below shows how yo
 can run `nginx` on either of these base configs.
 
 ```
-moby build -format docker -o - docker.yml nginx.yml | docker build -t dockertest -
+moby build -format docker -o - linuxkit.yml nginx.yml | docker build -t dockertest -
 docker run -d -p 80:80 --privileged dockertest
 
 moby build -format kernel+initrd linuxkit.yml nginx.yml


### PR DESCRIPTION
This one fixes the example command producing a docker image to use the existing files and be consistent with the standard VM image.

Signed-off-by: Tobias Gesellchen <tobias@gesellix.de>