### PR TITLE
Split config-related fields of Image into a substruct.

### DIFF
--- a/src/moby/config.go
+++ b/src/moby/config.go
@@ -62,8 +62,14 @@ type File struct {
 
 // Image is the type of an image config
 type Image struct {
-	Name              string                  `yaml:"name" json:"name"`
-	Image             string                  `yaml:"image" json:"image"`
+	Name        string `yaml:"name" json:"name"`
+	Image       string `yaml:"image" json:"image"`
+	ImageConfig `yaml:",inline"`
+}
+
+// ImageConfig is the configuration part of Image, it is the subset
+// which is valid in a "org.mobyproject.config" label on an image.
+type ImageConfig struct {
 	Capabilities      *[]string               `yaml:"capabilities" json:"capabilities,omitempty"`
 	Ambient           *[]string               `yaml:"ambient" json:"ambient,omitempty"`
 	Mounts            *[]specs.Mount          `yaml:"mounts" json:"mounts,omitempty"`

--- a/src/moby/config_test.go
+++ b/src/moby/config_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/docker/docker/api/types/container"
 )
 
-func setupInspect(t *testing.T, label Image) types.ImageInspect {
+func setupInspect(t *testing.T, label ImageConfig) types.ImageInspect {
 	var inspect types.ImageInspect
 	var config container.Config
 
@@ -30,14 +30,16 @@ func TestOverrides(t *testing.T) {
 	var yamlCaps = []string{"CAP_SYS_ADMIN"}
 
 	var yaml = Image{
-		Name:         "test",
-		Image:        "testimage",
-		Capabilities: &yamlCaps,
+		Name:  "test",
+		Image: "testimage",
+		ImageConfig: ImageConfig{
+			Capabilities: &yamlCaps,
+		},
 	}
 
 	var labelCaps = []string{"CAP_SYS_CHROOT"}
 
-	var label = Image{
+	var label = ImageConfig{
 		Capabilities: &labelCaps,
 		Cwd:          "/label/directory",
 	}
@@ -66,7 +68,7 @@ func TestInvalidCap(t *testing.T) {
 	}
 
 	labelCaps := []string{"NOT_A_CAP"}
-	var label = Image{
+	var label = ImageConfig{
 		Capabilities: &labelCaps,
 	}
 
@@ -87,11 +89,13 @@ func TestIdMap(t *testing.T) {
 	yaml := Image{
 		Name:  "test",
 		Image: "testimage",
-		UID:   &uid,
-		GID:   &gid,
+		ImageConfig: ImageConfig{
+			UID: &uid,
+			GID: &gid,
+		},
 	}
 
-	var label = Image{}
+	var label = ImageConfig{}
 
 	inspect := setupInspect(t, label)
 


### PR DESCRIPTION
Where "config-related" here means "ones you might find in the
"org.mobyproject.config" label on an image.

By making this new struct an anonymous member of the existing Image struct the
Go json parser does the right thing (i.e. inlines into the parent) when parsing
a complete image (from a yml assembly) by default. The Go yaml library which we
use requires a tag on the anonymous field to achieve the same.

Signed-off-by: Ian Campbell <ijc@docker.com>

My use case here is moving the `org.mobyproject.config` label definition out of the `Dockerfile` and into the `build.yml` consumed by `linuxkit pkg build`, which will be a PR to the linuxkit tool that'll I wil raise shortly. Splitting the `struct` like this avoids spurious empty `name` & `image` fields appearing in the label's content.