### PR TITLE
Reduce maximum memory usage via tempfiles

### DIFF
--- a/src/moby/docker.go
+++ b/src/moby/docker.go
@@ -4,7 +4,6 @@ package moby
 // and also using the Docker API not shelling out
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"io"
@@ -81,25 +80,18 @@ func dockerCreate(image string) (string, error) {
 	return respBody.ID, nil
 }
 
-func dockerExport(container string) ([]byte, error) {
+func dockerExport(container string) (io.ReadCloser, error) {
 	log.Debugf("docker export: %s", container)
 	cli, err := dockerClient()
 	if err != nil {
-		return []byte{}, errors.New("could not initialize Docker API client")
+		return nil, errors.New("could not initialize Docker API client")
 	}
 	responseBody, err := cli.ContainerExport(context.Background(), container)
 	if err != nil {
-		return []byte{}, err
-	}
-	defer responseBody.Close()
-
-	output := bytes.NewBuffer(nil)
-	_, err = io.Copy(output, responseBody)
-	if err != nil {
-		return []byte{}, err
+		return nil, err
 	}
 
-	return output.Bytes(), nil
+	return responseBody, err
 }
 
 func dockerRm(container string) error {

--- a/src/moby/image.go
+++ b/src/moby/image.go
@@ -119,6 +119,8 @@ func ImageTar(ref *reference.Spec, prefix string, tw tarWriter, trust bool, pull
 	if err != nil {
 		return fmt.Errorf("Failed to docker export container from container %s: %v", container, err)
 	}
+	defer contents.Close()
+
 	err = dockerRm(container)
 	if err != nil {
 		return fmt.Errorf("Failed to docker rm container %s: %v", container, err)
@@ -126,8 +128,7 @@ func ImageTar(ref *reference.Spec, prefix string, tw tarWriter, trust bool, pull
 
 	// now we need to filter out some files from the resulting tar archive
 
-	r := bytes.NewReader(contents)
-	tr := tar.NewReader(r)
+	tr := tar.NewReader(contents)
 
 	for {
 		hdr, err := tr.Next()


### PR DESCRIPTION
Replacing a few uses of `bytes.Buffer` with temporary files or passing around `io.Reader` instead of a full buffer reduces the Maximum RSS (measured by `time(1)`) from 6.7G to 110M when building the `kube-master.iso` from https://github.com/linuxkit/kubernetes.

Motivation for looking into this was that in the https://github.com/linuxkit/kubernetes CI the image build process is occasionally being SIGKILL'd, since the CI containers are limited to 4G I hypothesised that the process was being OOM killed (I have not yet tested with these changes in place).

Since i have plenty of RAM no my test system the data, presumably, remains hot in the page cache so elapsed wallclock time is unaffected (it's a few seconds faster on a minute long build, so in the noise). On a memory (but not disk) constrained system it ought to complete slowly instead of getting killed.

Also adds `-memprofile` and `-cpuprofile` options to enable measurement, although I mostly ended up using `time(1) since the profiles show cumulative or overall allocations rather than max rss.

I'm not sure but with these changes it might be possible to mark some additional image formats as streaming.