### PR TITLE
Add support for Intel ucode

### DIFF
--- a/docs/yaml.md
+++ b/docs/yaml.md
@@ -47,6 +47,10 @@ contain a kernel modules directory. `cmdline` specifies the kernel command line 
 To override the names, you can specify the kernel image name with `binary: bzImage` and the tar image
 with `tar: kernel.tar` or the empty string or `none` if you do not want to use a tarball at all.
 
+Kernel packages may also contain a cpio archive containing CPU microcode which needs prepending to
+the initrd. To select this option, recommended when booting on bare metal, add `ucode: intel-ucode.cpio`
+to the kernel section.
+
 ## `init`
 
 The `init` section is a list of images that are used for the `init` system and are unpacked directly

--- a/src/initrd/initrd.go
+++ b/src/initrd/initrd.go
@@ -110,13 +110,13 @@ func CopyTar(w *Writer, r *tar.Reader) (written int64, err error) {
 	}
 }
 
-// CopySplitTar copies a tar stream into an initrd, but splits out kernel and cmdline
-func CopySplitTar(w *Writer, r *tar.Reader) (kernel []byte, cmdline string, err error) {
+// CopySplitTar copies a tar stream into an initrd, but splits out kernel, cmdline, and ucode
+func CopySplitTar(w *Writer, r *tar.Reader) (kernel []byte, cmdline string, ucode []byte, err error) {
 	for {
 		var thdr *tar.Header
 		thdr, err = r.Next()
 		if err == io.EOF {
-			return kernel, cmdline, nil
+			return kernel, cmdline, ucode, nil
 		}
 		if err != nil {
 			return
@@ -134,6 +134,11 @@ func CopySplitTar(w *Writer, r *tar.Reader) (kernel []byte, cmdline string, err 
 				return
 			}
 			cmdline = string(buf)
+		case "boot/ucode.cpio":
+			ucode, err = ioutil.ReadAll(r)
+			if err != nil {
+				return
+			}
 		case "boot":
 			// skip this entry
 		default:

--- a/src/moby/config.go
+++ b/src/moby/config.go
@@ -36,6 +36,7 @@ type KernelConfig struct {
 	Cmdline string  `yaml:"cmdline,omitempty" json:"cmdline,omitempty"`
 	Binary  string  `yaml:"binary,omitempty" json:"binary,omitempty"`
 	Tar     *string `yaml:"tar,omitempty" json:"tar,omitempty"`
+	UCode   *string `yaml:"ucode,omitempty" json:"ucode,omitempty"`
 
 	ref *reference.Spec
 }
@@ -288,6 +289,9 @@ func AppendConfig(m0, m1 Moby) (Moby, error) {
 	}
 	if m1.Kernel.Tar != nil {
 		moby.Kernel.Tar = m1.Kernel.Tar
+	}
+	if m1.Kernel.UCode != nil {
+		moby.Kernel.UCode = m1.Kernel.UCode
 	}
 	if m1.Kernel.ref != nil {
 		moby.Kernel.ref = m1.Kernel.ref

--- a/src/moby/linuxkit.go
+++ b/src/moby/linuxkit.go
@@ -72,7 +72,7 @@ func ensureLinuxkitImage(name string) error {
 		return err
 	}
 	defer image.Close()
-	kernel, initrd, cmdline, err := tarToInitrd(image)
+	kernel, initrd, cmdline, _, err := tarToInitrd(image)
 	if err != nil {
 		return fmt.Errorf("Error converting to initrd: %v", err)
 	}

--- a/src/moby/schema.go
+++ b/src/moby/schema.go
@@ -13,7 +13,8 @@ var schema = string(`
         "image": {"type": "string"},
         "cmdline": {"type": "string"},
         "binary": {"type": "string"},
-        "tar": {"type": "string"}
+        "tar": {"type": "string"},
+        "ucode": {"type": "string"}
       }
     },
     "file": {


### PR DESCRIPTION
https://github.com/linuxkit/linuxkit/pull/2858 adds the Intel CPU ucode for all CPUs to the kernel package as `intel-ucode.cpio`. It is a cpio archive which needs to be prepended to the intrd (or if the booloader supports specifying multiple initrds it must be listed as the first).

This PR then adds:
- a new `ucode` option to the kernel section of the YAML to specify the cpio archive containing the ucode.
- adds the specified ucode as `/boot/ucode.cpio` in the intermediate tar ball
- extracts the ucode binary as part of the output phase
- prepends it to the initrd for `kernel+initrd` output
- adds it to the tar-kernel-initrd tarball

Som additional output formats, in particualr the raw disk and ISO variants should probably also get the support.

I've tested the resulting kernel+initrd files with and without ucode on hyperkit and packet.net. On packet.net with ucode we see:
```
[    0.000000] microcode: microcode updated early to revision 0xc2, date = 2017-11-16
[    0.000000] Linux version 4.14.13-linuxkit (root@feac4b18d1e6) (gcc version 6.4.0 (Alpine 6.4.b)) #1 SMP Mon Jan 15 11:20:07 UTC 2018
```
as the first line of the boot indicating the ucode update works.