### PR TITLE
Add support for OCI annotations in config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ ifndef GOMETALINTER
 endif
 	gometalinter --config gometalinter.json ./...
 
+.PHONY: test
 test: dist/moby
 	@go test $(shell go list ./... | grep -vE '/vendor/')
 	# test build

--- a/docs/yaml.md
+++ b/docs/yaml.md
@@ -181,8 +181,9 @@ bind mounted into a container.
 - `rootfsPropagation` sets the rootfs propagation, eg `shared`, `slave` or (default) `private`.
 - `cgroupsPath` sets the path for cgroups.
 - `resources` sets cgroup resource limits as per the OCI spec.
-- `sysctl` sets a list of `sysctl` key value pairs that are set inside the container namespace.
+- `sysctl` sets a map of `sysctl` key value pairs that are set inside the container namespace.
 - `rmlimits` sets a list of `rlimit` values in the form `name,soft,hard`, eg `nofile,100,200`. You can use `unlimited` as a value too.
+- `annotations` sets a map of key value pairs as OCI metadata.
 
 There are experimental `userns`, `uidMappings` and `gidMappings` options for user namespaces but these are not yet supported, and may have
 permissions issues in use.

--- a/src/moby/config.go
+++ b/src/moby/config.go
@@ -70,6 +70,7 @@ type Image struct {
 
 // ImageConfig is the configuration part of Image, it is the subset
 // which is valid in a "org.mobyproject.config" label on an image.
+// Everything except Runtime and ref is used to build the OCI spec
 type ImageConfig struct {
 	Capabilities      *[]string               `yaml:"capabilities,omitempty" json:"capabilities,omitempty"`
 	Ambient           *[]string               `yaml:"ambient,omitempty" json:"ambient,omitempty"`
@@ -100,7 +101,9 @@ type ImageConfig struct {
 	Rlimits           *[]string               `yaml:"rlimits,omitempty" json:"rlimits,omitempty"`
 	UIDMappings       *[]specs.LinuxIDMapping `yaml:"uidMappings,omitempty" json:"uidMappings,omitempty"`
 	GIDMappings       *[]specs.LinuxIDMapping `yaml:"gidMappings,omitempty" json:"gidMappings,omitempty"`
-	Runtime           *Runtime                `yaml:"runtime,omitempty" json:"runtime,omitempty"`
+	Annotations       *map[string]string      `yaml:"annotations,omitempty" json:"annotations,omitempty"`
+
+	Runtime *Runtime `yaml:"runtime,omitempty" json:"runtime,omitempty"`
 
 	ref *reference.Spec
 }
@@ -1025,6 +1028,7 @@ func ConfigInspectToOCI(yaml *Image, inspect types.ImageInspect, idMap map[strin
 
 	oci.Hostname = assignStringEmpty(label.Hostname, yaml.Hostname)
 	oci.Mounts = mountList
+	oci.Annotations = assignMaps(label.Annotations, yaml.Annotations)
 
 	resources := assignResources(label.Resources, yaml.Resources)
 

--- a/src/moby/schema.go
+++ b/src/moby/schema.go
@@ -49,6 +49,10 @@ var schema = string(`
         "type": "array",
         "items": {"type": "string"}
     },
+    "mapstring": {
+        "type": "object",
+        "additionalProperties": {"type": "string"}
+    },
     "mount": {
       "type": "object",
       "additionalProperties": false,
@@ -282,13 +286,11 @@ var schema = string(`
         "rootfsPropagation": {"type": "string"},
         "cgroupsPath": {"type": "string"},
         "resources": {"$ref": "#/definitions/resources"},
-        "sysctl": {
-            "type": "array",
-            "items": { "$ref": "#/definitions/strings" }
-        },
+        "sysctl": { "$ref": "#/definitions/mapstring" },
         "rlimits": { "$ref": "#/definitions/strings" },
         "uidMappings": { "$ref": "#/definitions/idmappings" },
         "gidMappings": { "$ref": "#/definitions/idmappings" },
+        "annotations": { "$ref": "#/definitions/mapstring" },
         "runtime": {"$ref": "#/definitions/runtime"}
       }
     },

--- a/test/test.yml
+++ b/test/test.yml
@@ -36,6 +36,9 @@ services:
           access: rwm
       pids:
         limit: 10
+    annotations:
+      annotate: this
+      org.opencontainers.example: "reserved annotation"
 files:
   - path: etc/docker/daemon.json
     contents: '{"debug": true}'


### PR DESCRIPTION
Annotations do not do anything by default but get passed through to the runtime, which can be useful. I never metadata I didn't like...
    
Also fix sysctl to be a map in the validation, not an array. I can't see any examples using this in LinuxKit, but this matches OCI so is correct.
