### PR TITLE
Add support for setting containerd namespace in runtime config

### DIFF
--- a/docs/yaml.md
+++ b/docs/yaml.md
@@ -202,6 +202,7 @@ which specifies some actions to take place when the container is being started.
   - `peer` specifies the name of the other end when creating a `veth` interface. This end will remain in the root namespace, where it can be attached to a bridge. Specifying this implies `add: veth`.
 - `bindNS` specifies a namespace type and a path where the namespace from the container being created will be bound. This allows a namespace to be set up in an `onboot` container, and then
   using `net: path` for a `service` container to use that network namespace later.
+- `namespace` overrides the LinuxKit default containerd namespace to put the container in; only applicable to services.
 
 An example of using the `runtime` config to configure a network namespace with `wireguard` and then run `nginx` in that namespace is shown below:
 ```

--- a/src/moby/config.go
+++ b/src/moby/config.go
@@ -115,6 +115,7 @@ type Runtime struct {
 	Mkdir      *[]string      `yaml:"mkdir,omitempty" json:"mkdir,omitempty"`
 	Interfaces *[]Interface   `yaml:"interfaces,omitempty,omitempty" json:"interfaces,omitempty"`
 	BindNS     Namespaces     `yaml:"bindNS,omitempty" json:"bindNS,omitempty"`
+	Namespace  *string        `yaml:"namespace,omitempty" json:"namespace,omitempty"`
 }
 
 // Namespaces is the type for configuring paths to bind namespaces
@@ -588,6 +589,7 @@ func assignRuntime(v1, v2 *Runtime) Runtime {
 	runtimeMounts := assignBinds(v1.Mounts, v2.Mounts)
 	runtimeMkdir := assignStrings(v1.Mkdir, v2.Mkdir)
 	runtimeInterfaces := assignRuntimeInterfaceArray(v1.Interfaces, v2.Interfaces)
+	runtimeNamespace := assignString(v1.Namespace, v2.Namespace)
 	runtime := Runtime{
 		Cgroups:    &runtimeCgroups,
 		Mounts:     &runtimeMounts,
@@ -602,6 +604,7 @@ func assignRuntime(v1, v2 *Runtime) Runtime {
 			User:   assignStringPtr(v1.BindNS.User, v2.BindNS.User),
 			Uts:    assignStringPtr(v1.BindNS.Uts, v2.BindNS.Uts),
 		},
+		Namespace: &runtimeNamespace,
 	}
 	return runtime
 }

--- a/src/moby/schema.go
+++ b/src/moby/schema.go
@@ -248,7 +248,8 @@ var schema = string(`
         "mounts": {"$ref": "#/definitions/mounts"},
         "mkdir": {"$ref": "#/definitions/strings"},
         "interfaces": {"$ref": "#/definitions/interfaces"},
-        "bindNS": {"$ref": "#/definitions/namespaces"}
+        "bindNS": {"$ref": "#/definitions/namespaces"},
+        "namespace": {"type": "string"}
       }
     },
     "image": {


### PR DESCRIPTION
This adds a namespace field to override the LinuxKit containerd
default namespace, in case you want to run a container in another
namespace.

Needs a patch in LinuxKit to implement this that I will open soon.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>