### PR TITLE
The vmdk and dynamic-vhd packages had a bug in them

### DIFF
--- a/src/moby/output.go
+++ b/src/moby/output.go
@@ -20,8 +20,8 @@ const (
 	rawEfi     = "linuxkit/mkimage-raw-efi:82db3af46d299be160590fb1633bbfebc891a927"
 	gcp        = "linuxkit/mkimage-gcp:df4f46fbcabcfef84af2ff34ff1ef7e7673bc329"
 	vhd        = "linuxkit/mkimage-vhd:796acfc515c22afb8f32d6b5c4bdd456b7f79d8c"
-	vmdk       = "linuxkit/mkimage-vmdk:a72b81b7f1748d24bf24a1ab759d4ade4d74fe69"
-	dynamicvhd = "linuxkit/mkimage-dynamic-vhd:8bc80f9e4bc55e7ea500c40d6b53cf493e3ee454"
+	vmdk       = "linuxkit/mkimage-vmdk:deb9018d06dbb9da29464a4320187ce7e4ae1856"
+	dynamicvhd = "linuxkit/mkimage-dynamic-vhd:172fb196713a4aff677b88422026512600b1ca55"
 	rpi3       = "linuxkit/mkimage-rpi3:553c6c2d13b7d54f6b73b3b0c1c15f2e47ffb0df"
 )
 


### PR DESCRIPTION
This picks up a newer version

Signed-off-by: Rolf Neugebauer <rolf.neugebauer@docker.com>