### PR TITLE
Add documentation about using images from private registries

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# Moby
+
+[Moby Project](https://mobyproject.org)
+
+The Moby Project is an open framework to assemble specialized container systems without reinventing the wheel.
+
+Moby is an open framework created by Docker to assemble specialized container systems without reinventing the wheel. It provides a “lego set” of dozens of standard components and a framework for assembling them into custom platforms. At the core of Moby is a framework to assemble specialized container systems which provides:
+
+For more information, please visit the [Moby Project home page](https://mobyproject.org).
+
+## Documentation
+
+* [Format of moby input yml](./docs/yaml.md)
+* [Using private images}(./docs/privateimages.md)

--- a/docs/privateimages.md
+++ b/docs/privateimages.md
@@ -1,0 +1,13 @@
+## Private Images
+When building, `moby` downloads, and optionally checks the notary signature, on any OCI images referenced in any section. 
+
+As of this writing, `moby` does **not** have the ability to download these images from registries that require credentials to access. This is equally true for private images on public registries, like https://hub.docker.com, as for private registries.
+
+We are working on enabling private images with credentials. Until such time as that feature is added, you can follow these steps to build a moby image using OCI images
+that require credentials to access:
+
+1. `docker login` as relevant to authenticate against the desired registry.
+2. `docker pull` to download the images to your local machine where you will run `moby build`.
+3. Run `moby build` (or `linuxkit build`).
+
+Additionally, ensure that you do **not** have trust enabled for those images. See the section on [trust](#trust) in this document. Alternately, you can run `moby build` or `linuxkit build` with `--disable-trust`.


### PR DESCRIPTION
As of right now, `moby build` (and by extension `linuxkit build`) do not read the executing user's docker credentials. This means that moby images cannot be composed of OCI images that require credentials to access, e.g. private images on a public registry like Docker Hub, or images on a private registry.

While there are plans to support credentials, this documentation change should enable people to know of the issue and work around it until such time as support is in place.

Signed-off-by: Avi Deitcher <avi@deitcher.net>