### PR TITLE
Default bind mounts to rshared not rprivate if not specified

### DIFF
--- a/src/moby/config.go
+++ b/src/moby/config.go
@@ -785,7 +785,8 @@ func ConfigInspectToOCI(yaml *Image, inspect types.ImageInspect, idMap map[strin
 		}
 		src := parts[0]
 		dest := parts[1]
-		opts := []string{"rw", "rbind", "rprivate"}
+		// default to rshared if not specified
+		opts := []string{"rw", "rbind", "rshared"}
 		if len(parts) == 3 {
 			opts = append(strings.Split(parts[2], ","), "rbind")
 		}


### PR DESCRIPTION
It is quite confusing that from the host or another container that
binds `/containers` you cannot see the bind mounts, you have to enter
the container namespace. I think `rshared` is a better default. You
can always be explicit and add `private` if you want a private bind mount.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>