### PR TITLE
Add ability to overwrite images used for outputs

### DIFF
--- a/src/moby/output.go
+++ b/src/moby/output.go
@@ -13,18 +13,32 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-const (
-	isoBios    = "linuxkit/mkimage-iso-bios:9a51dc64a461f1cc50ba05f30a38f73f5227ac03"
-	isoEfi     = "linuxkit/mkimage-iso-efi:343cf1a8ac0aba7d8a1f13b7f45fa0b57ab897dc"
-	rawBios    = "linuxkit/mkimage-raw-bios:d90713b2dd610cf9a0f5f9d9095f8bf86f40d5c6"
-	rawEfi     = "linuxkit/mkimage-raw-efi:8938ffb6014543e557b624a40cce1714f30ce4b6"
-	gcp        = "linuxkit/mkimage-gcp:e6cdcf859ab06134c0c37a64ed5f886ec8dae1a1"
-	vhd        = "linuxkit/mkimage-vhd:3820219e5c350fe8ab2ec6a217272ae82f4b9242"
-	vmdk       = "linuxkit/mkimage-vmdk:cee81a3ed9c44ae446ef7ebff8c42c1e77b3e1b5"
-	dynamicvhd = "linuxkit/mkimage-dynamic-vhd:743ac9959fe6d3912ebd78b4fd490b117c53f1a6"
-	rpi3       = "linuxkit/mkimage-rpi3:0f23c4f37cdca99281ca33ac6188e1942fa7a2b8"
-	qcow2Efi   = "linuxkit/mkimage-qcow2-efi:787b54906e14a56b9f1da35dcc8e46bd58435285"
+var (
+	outputImages = map[string]string{
+		"iso-bios":    "linuxkit/mkimage-iso-bios:9a51dc64a461f1cc50ba05f30a38f73f5227ac03",
+		"iso-efi":     "linuxkit/mkimage-iso-efi:343cf1a8ac0aba7d8a1f13b7f45fa0b57ab897dc",
+		"raw-bios":    "linuxkit/mkimage-raw-bios:d90713b2dd610cf9a0f5f9d9095f8bf86f40d5c6",
+		"raw-efi":     "linuxkit/mkimage-raw-efi:8938ffb6014543e557b624a40cce1714f30ce4b6",
+		"gcp":         "linuxkit/mkimage-gcp:e6cdcf859ab06134c0c37a64ed5f886ec8dae1a1",
+		"qcow2-efi":   "linuxkit/mkimage-qcow2-efi:787b54906e14a56b9f1da35dcc8e46bd58435285",
+		"vhd":         "linuxkit/mkimage-vhd:3820219e5c350fe8ab2ec6a217272ae82f4b9242",
+		"dynamic-vhd": "linuxkit/mkimage-dynamic-vhd:743ac9959fe6d3912ebd78b4fd490b117c53f1a6",
+		"vmdk":        "linuxkit/mkimage-vmdk:cee81a3ed9c44ae446ef7ebff8c42c1e77b3e1b5",
+		"rpi3":        "linuxkit/mkimage-rpi3:0f23c4f37cdca99281ca33ac6188e1942fa7a2b8",
+	}
 )
+
+// UpdateOutputImages overwrite the docker images used to build the outputs
+// 'update' is a map where the key is the output format and the value is a LinuxKit 'mkimage' image.
+func UpdateOutputImages(update map[string]string) error {
+	for k, img := range update {
+		if _, ok := outputImages[k]; !ok {
+			return fmt.Errorf("Image format %s is not known", k)
+		}
+		outputImages[k] = img
+	}
+	return nil
+}
 
 var outFuns = map[string]func(string, io.Reader, int) error{
 	"kernel+initrd": func(base string, image io.Reader, size int) error {
@@ -49,14 +63,14 @@ var outFuns = map[string]func(string, io.Reader, int) error{
 		return nil
 	},
 	"iso-bios": func(base string, image io.Reader, size int) error {
-		err := outputIso(isoBios, base+".iso", image)
+		err := outputIso(outputImages["iso-bios"], base+".iso", image)
 		if err != nil {
 			return fmt.Errorf("Error writing iso-bios output: %v", err)
 		}
 		return nil
 	},
 	"iso-efi": func(base string, image io.Reader, size int) error {
-		err := outputIso(isoEfi, base+"-efi.iso", image)
+		err := outputIso(outputImages["iso-efi"], base+"-efi.iso", image)
 		if err != nil {
 			return fmt.Errorf("Error writing iso-efi output: %v", err)
 		}
@@ -68,7 +82,7 @@ var outFuns = map[string]func(string, io.Reader, int) error{
 			return fmt.Errorf("Error converting to initrd: %v", err)
 		}
 		// TODO: Handle ucode
-		err = outputImg(rawBios, base+"-bios.img", kernel, initrd, cmdline)
+		err = outputImg(outputImages["raw-bios"], base+"-bios.img", kernel, initrd, cmdline)
 		if err != nil {
 			return fmt.Errorf("Error writing raw-bios output: %v", err)
 		}
@@ -79,7 +93,7 @@ var outFuns = map[string]func(string, io.Reader, int) error{
 		if err != nil {
 			return fmt.Errorf("Error converting to initrd: %v", err)
 		}
-		err = outputImg(rawEfi, base+"-efi.img", kernel, initrd, cmdline)
+		err = outputImg(outputImages["raw-efi"], base+"-efi.img", kernel, initrd, cmdline)
 		if err != nil {
 			return fmt.Errorf("Error writing raw-efi output: %v", err)
 		}
@@ -103,7 +117,7 @@ var outFuns = map[string]func(string, io.Reader, int) error{
 		if err != nil {
 			return fmt.Errorf("Error converting to initrd: %v", err)
 		}
-		err = outputImg(gcp, base+".img.tar.gz", kernel, initrd, cmdline)
+		err = outputImg(outputImages["gcp"], base+".img.tar.gz", kernel, initrd, cmdline)
 		if err != nil {
 			return fmt.Errorf("Error writing gcp output: %v", err)
 		}
@@ -114,7 +128,7 @@ var outFuns = map[string]func(string, io.Reader, int) error{
 		if err != nil {
 			return fmt.Errorf("Error converting to initrd: %v", err)
 		}
-		err = outputImg(qcow2Efi, base+"-efi.qcow2", kernel, initrd, cmdline)
+		err = outputImg(outputImages["qcow2-efi"], base+"-efi.qcow2", kernel, initrd, cmdline)
 		if err != nil {
 			return fmt.Errorf("Error writing qcow2 EFI output: %v", err)
 		}
@@ -139,7 +153,7 @@ var outFuns = map[string]func(string, io.Reader, int) error{
 		if err != nil {
 			return fmt.Errorf("Error converting to initrd: %v", err)
 		}
-		err = outputImg(vhd, base+".vhd", kernel, initrd, cmdline)
+		err = outputImg(outputImages["vhd"], base+".vhd", kernel, initrd, cmdline)
 		if err != nil {
 			return fmt.Errorf("Error writing vhd output: %v", err)
 		}
@@ -150,7 +164,7 @@ var outFuns = map[string]func(string, io.Reader, int) error{
 		if err != nil {
 			return fmt.Errorf("Error converting to initrd: %v", err)
 		}
-		err = outputImg(dynamicvhd, base+".vhd", kernel, initrd, cmdline)
+		err = outputImg(outputImages["dynamic-vhd"], base+".vhd", kernel, initrd, cmdline)
 		if err != nil {
 			return fmt.Errorf("Error writing vhd output: %v", err)
 		}
@@ -161,7 +175,7 @@ var outFuns = map[string]func(string, io.Reader, int) error{
 		if err != nil {
 			return fmt.Errorf("Error converting to initrd: %v", err)
 		}
-		err = outputImg(vmdk, base+".vmdk", kernel, initrd, cmdline)
+		err = outputImg(outputImages["vmdk"], base+".vmdk", kernel, initrd, cmdline)
 		if err != nil {
 			return fmt.Errorf("Error writing vmdk output: %v", err)
 		}
@@ -171,7 +185,7 @@ var outFuns = map[string]func(string, io.Reader, int) error{
 		if runtime.GOARCH != "arm64" {
 			return fmt.Errorf("Raspberry Pi output currently only supported on arm64")
 		}
-		err := outputRPi3(rpi3, base+".tar", image)
+		err := outputRPi3(outputImages["rpi3"], base+".tar", image)
 		if err != nil {
 			return fmt.Errorf("Error writing rpi3 output: %v", err)
 		}


### PR DESCRIPTION
We currently hardcode the Linuxkit/mkimage- images. This has the
unfortunate consequence that, if we update the LinuxKit image used
to generate the output, we have to update the Moby tool and then
vendor it back into the LinuxKit repository.

This commit introduces UpdateOutputImages() which allows a client
of the Moby tools package to selectively overwrite the packages
used to generate the outputs.

We keep the full image names (name + tag) intact in the source
to make it easier to update them with 'sed'. From the image names
we generate a map which can be updated with UpdateOutputImages().

See: https://github.com/moby/tool/pull/211#issuecomment-378893730

Signed-off-by: Rolf Neugebauer <rolf.neugebauer@gmail.com>