### PR TITLE
Add  'kernel+squashfs' output format

### DIFF
--- a/src/initrd/initrd.go
+++ b/src/initrd/initrd.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"io/ioutil"
 	"path/filepath"
+	"strings"
 
 	"github.com/moby/tool/src/pad4"
 	"github.com/surma/gocpio"
@@ -121,26 +122,26 @@ func CopySplitTar(w *Writer, r *tar.Reader) (kernel []byte, cmdline string, ucod
 		if err != nil {
 			return
 		}
-		switch thdr.Name {
-		case "boot/kernel":
+		switch {
+		case thdr.Name == "boot/kernel":
 			kernel, err = ioutil.ReadAll(r)
 			if err != nil {
 				return
 			}
-		case "boot/cmdline":
+		case thdr.Name == "boot/cmdline":
 			var buf []byte
 			buf, err = ioutil.ReadAll(r)
 			if err != nil {
 				return
 			}
 			cmdline = string(buf)
-		case "boot/ucode.cpio":
+		case thdr.Name == "boot/ucode.cpio":
 			ucode, err = ioutil.ReadAll(r)
 			if err != nil {
 				return
 			}
-		case "boot":
-			// skip this entry
+		case strings.HasPrefix(thdr.Name, "boot/"):
+			// skip the rest of ./boot
 		default:
 			_, err = copyTarEntry(w, thdr, r)
 			if err != nil {

--- a/src/moby/docker.go
+++ b/src/moby/docker.go
@@ -22,7 +22,7 @@ import (
 )
 
 func dockerRun(input io.Reader, output io.Writer, trust bool, img string, args ...string) error {
-	log.Debugf("docker run (input): %s", strings.Join(args, " "))
+	log.Debugf("docker run %s (trust=%t) (input): %s", img, trust, strings.Join(args, " "))
 	docker, err := exec.LookPath("docker")
 	if err != nil {
 		return errors.New("Docker does not seem to be installed")
@@ -38,7 +38,7 @@ func dockerRun(input io.Reader, output io.Writer, trust bool, img string, args .
 	pull.Env = env
 	if err := pull.Run(); err != nil {
 		if exitError, ok := err.(*exec.ExitError); ok {
-			return fmt.Errorf("docker pull failed: %v output:\n%s", err, exitError.Stderr)
+			return fmt.Errorf("docker pull %s failed: %v output:\n%s", img, err, exitError.Stderr)
 		}
 		return err
 	}
@@ -51,12 +51,12 @@ func dockerRun(input io.Reader, output io.Writer, trust bool, img string, args .
 
 	if err := cmd.Run(); err != nil {
 		if exitError, ok := err.(*exec.ExitError); ok {
-			return fmt.Errorf("docker run failed: %v output:\n%s", err, exitError.Stderr)
+			return fmt.Errorf("docker run %s failed: %v output:\n%s", img, err, exitError.Stderr)
 		}
 		return err
 	}
 
-	log.Debugf("docker run (input): %s...Done", strings.Join(args, " "))
+	log.Debugf("docker run %s (input): %s...Done", img, strings.Join(args, " "))
 	return nil
 }
 


### PR DESCRIPTION
This output produces a kernel and a root filesystem in squashfs format. squashfs is a read-only, compressed filesystem.

The 'kernel+squashfs' output can be used in a similar way as the default 'kernel+initrd' output format with the benefit that the rootfs does not consume any memory.

There is an additional commit which improves the logging for `dockerRun()`.

The `linuxkit/mkimage-squashfs` is already build and pushed.