### PR TITLE
Use GNU tar format

### DIFF
--- a/src/moby/build.go
+++ b/src/moby/build.go
@@ -49,9 +49,10 @@ var additions = map[string]addFun{
 	"docker": func(tw *tar.Writer) error {
 		log.Infof("  Adding Dockerfile")
 		hdr := &tar.Header{
-			Name: "Dockerfile",
-			Mode: 0644,
-			Size: int64(len(dockerfile)),
+			Name:   "Dockerfile",
+			Mode:   0644,
+			Size:   int64(len(dockerfile)),
+			Format: tar.FormatGNU,
 		}
 		if err := tw.WriteHeader(hdr); err != nil {
 			return err
@@ -340,6 +341,7 @@ func (k *kernelFilter) WriteHeader(hdr *tar.Header) error {
 				Name:     "boot",
 				Mode:     0755,
 				Typeflag: tar.TypeDir,
+				Format:   tar.FormatGNU,
 			}
 			if err := tw.WriteHeader(whdr); err != nil {
 				return err
@@ -347,9 +349,10 @@ func (k *kernelFilter) WriteHeader(hdr *tar.Header) error {
 		}
 		// add the cmdline in /boot/cmdline
 		whdr := &tar.Header{
-			Name: "boot/cmdline",
-			Mode: 0644,
-			Size: int64(len(k.cmdline)),
+			Name:   "boot/cmdline",
+			Mode:   0644,
+			Size:   int64(len(k.cmdline)),
+			Format: tar.FormatGNU,
 		}
 		if err := tw.WriteHeader(whdr); err != nil {
 			return err
@@ -360,9 +363,10 @@ func (k *kernelFilter) WriteHeader(hdr *tar.Header) error {
 			return err
 		}
 		whdr = &tar.Header{
-			Name: "boot/kernel",
-			Mode: hdr.Mode,
-			Size: hdr.Size,
+			Name:   "boot/kernel",
+			Mode:   hdr.Mode,
+			Size:   hdr.Size,
+			Format: tar.FormatGNU,
 		}
 		if err := tw.WriteHeader(whdr); err != nil {
 			return err
@@ -380,15 +384,17 @@ func (k *kernelFilter) WriteHeader(hdr *tar.Header) error {
 				Name:     "boot",
 				Mode:     0755,
 				Typeflag: tar.TypeDir,
+				Format:   tar.FormatGNU,
 			}
 			if err := tw.WriteHeader(whdr); err != nil {
 				return err
 			}
 		}
 		whdr := &tar.Header{
-			Name: "boot/ucode.cpio",
-			Mode: hdr.Mode,
-			Size: hdr.Size,
+			Name:   "boot/ucode.cpio",
+			Mode:   hdr.Mode,
+			Size:   hdr.Size,
+			Format: tar.FormatGNU,
 		}
 		if err := tw.WriteHeader(whdr); err != nil {
 			return err
@@ -544,6 +550,7 @@ func filesystem(m Moby, tw *tar.Writer, idMap map[string]uint32) error {
 					Mode:     dirMode,
 					Uid:      int(uid),
 					Gid:      int(gid),
+					Format:   tar.FormatGNU,
 				}
 				err := tw.WriteHeader(hdr)
 				if err != nil {
@@ -554,10 +561,11 @@ func filesystem(m Moby, tw *tar.Writer, idMap map[string]uint32) error {
 		}
 		addedFiles[f.Path] = true
 		hdr := &tar.Header{
-			Name: f.Path,
-			Mode: mode,
-			Uid:  int(uid),
-			Gid:  int(gid),
+			Name:   f.Path,
+			Mode:   mode,
+			Uid:    int(uid),
+			Gid:    int(gid),
+			Format: tar.FormatGNU,
 		}
 		if f.Directory {
 			if f.Contents != nil {

--- a/src/moby/image.go
+++ b/src/moby/image.go
@@ -72,6 +72,7 @@ func tarPrefix(path string, tw tarWriter) error {
 			Name:     mkdir,
 			Mode:     0755,
 			Typeflag: tar.TypeDir,
+			Format:   tar.FormatGNU,
 		}
 		if err := tw.WriteHeader(hdr); err != nil {
 			return err
@@ -217,9 +218,10 @@ func ImageBundle(prefix string, ref *reference.Spec, config []byte, runtime Runt
 	}
 
 	hdr := &tar.Header{
-		Name: path.Join(prefix, "config.json"),
-		Mode: 0644,
-		Size: int64(len(config)),
+		Name:   path.Join(prefix, "config.json"),
+		Mode:   0644,
+		Size:   int64(len(config)),
+		Format: tar.FormatGNU,
 	}
 	if err := tw.WriteHeader(hdr); err != nil {
 		return err
@@ -237,6 +239,7 @@ func ImageBundle(prefix string, ref *reference.Spec, config []byte, runtime Runt
 			Name:     tmp,
 			Mode:     0755,
 			Typeflag: tar.TypeDir,
+			Format:   tar.FormatGNU,
 		}
 		if err := tw.WriteHeader(hdr); err != nil {
 			return err
@@ -246,6 +249,7 @@ func ImageBundle(prefix string, ref *reference.Spec, config []byte, runtime Runt
 			Name:     path.Join(prefix, "rootfs"),
 			Mode:     0755,
 			Typeflag: tar.TypeDir,
+			Format:   tar.FormatGNU,
 		}
 		if err := tw.WriteHeader(hdr); err != nil {
 			return err
@@ -264,6 +268,7 @@ func ImageBundle(prefix string, ref *reference.Spec, config []byte, runtime Runt
 				Name:     path.Join(prefix, "rootfs"),
 				Mode:     0755,
 				Typeflag: tar.TypeDir,
+				Format:   tar.FormatGNU,
 			}
 			if err := tw.WriteHeader(hdr); err != nil {
 				return err
@@ -286,9 +291,10 @@ func ImageBundle(prefix string, ref *reference.Spec, config []byte, runtime Runt
 	}
 
 	hdr = &tar.Header{
-		Name: path.Join(prefix, "runtime.json"),
-		Mode: 0644,
-		Size: int64(len(runtimeConfig)),
+		Name:   path.Join(prefix, "runtime.json"),
+		Mode:   0644,
+		Size:   int64(len(runtimeConfig)),
+		Format: tar.FormatGNU,
 	}
 	if err := tw.WriteHeader(hdr); err != nil {
 		return err

--- a/src/moby/output.go
+++ b/src/moby/output.go
@@ -273,9 +273,10 @@ func tarInitrdKernel(kernel, initrd []byte, cmdline string) (*bytes.Buffer, erro
 	buf := new(bytes.Buffer)
 	tw := tar.NewWriter(buf)
 	hdr := &tar.Header{
-		Name: "kernel",
-		Mode: 0600,
-		Size: int64(len(kernel)),
+		Name:   "kernel",
+		Mode:   0600,
+		Size:   int64(len(kernel)),
+		Format: tar.FormatGNU,
 	}
 	err := tw.WriteHeader(hdr)
 	if err != nil {
@@ -286,9 +287,10 @@ func tarInitrdKernel(kernel, initrd []byte, cmdline string) (*bytes.Buffer, erro
 		return buf, err
 	}
 	hdr = &tar.Header{
-		Name: "initrd.img",
-		Mode: 0600,
-		Size: int64(len(initrd)),
+		Name:   "initrd.img",
+		Mode:   0600,
+		Size:   int64(len(initrd)),
+		Format: tar.FormatGNU,
 	}
 	err = tw.WriteHeader(hdr)
 	if err != nil {
@@ -299,9 +301,10 @@ func tarInitrdKernel(kernel, initrd []byte, cmdline string) (*bytes.Buffer, erro
 		return buf, err
 	}
 	hdr = &tar.Header{
-		Name: "cmdline",
-		Mode: 0600,
-		Size: int64(len(cmdline)),
+		Name:   "cmdline",
+		Mode:   0600,
+		Size:   int64(len(cmdline)),
+		Format: tar.FormatGNU,
 	}
 	err = tw.WriteHeader(hdr)
 	if err != nil {
@@ -389,9 +392,10 @@ func outputKernelInitrdTarball(base string, kernel []byte, initrd []byte, cmdlin
 	defer f.Close()
 	tw := tar.NewWriter(f)
 	hdr := &tar.Header{
-		Name: "kernel",
-		Mode: 0644,
-		Size: int64(len(kernel)),
+		Name:   "kernel",
+		Mode:   0644,
+		Size:   int64(len(kernel)),
+		Format: tar.FormatGNU,
 	}
 	if err := tw.WriteHeader(hdr); err != nil {
 		return err
@@ -400,9 +404,10 @@ func outputKernelInitrdTarball(base string, kernel []byte, initrd []byte, cmdlin
 		return err
 	}
 	hdr = &tar.Header{
-		Name: "initrd.img",
-		Mode: 0644,
-		Size: int64(len(initrd)),
+		Name:   "initrd.img",
+		Mode:   0644,
+		Size:   int64(len(initrd)),
+		Format: tar.FormatGNU,
 	}
 	if err := tw.WriteHeader(hdr); err != nil {
 		return err
@@ -411,9 +416,10 @@ func outputKernelInitrdTarball(base string, kernel []byte, initrd []byte, cmdlin
 		return err
 	}
 	hdr = &tar.Header{
-		Name: "cmdline",
-		Mode: 0644,
-		Size: int64(len(cmdline)),
+		Name:   "cmdline",
+		Mode:   0644,
+		Size:   int64(len(cmdline)),
+		Format: tar.FormatGNU,
 	}
 	if err := tw.WriteHeader(hdr); err != nil {
 		return err
@@ -423,9 +429,10 @@ func outputKernelInitrdTarball(base string, kernel []byte, initrd []byte, cmdlin
 	}
 	if len(ucode) != 0 {
 		hdr := &tar.Header{
-			Name: "ucode.cpio",
-			Mode: 0644,
-			Size: int64(len(ucode)),
+			Name:   "ucode.cpio",
+			Mode:   0644,
+			Size:   int64(len(ucode)),
+			Format: tar.FormatGNU,
 		}
 		if err := tw.WriteHeader(hdr); err != nil {
 			return err
@@ -454,6 +461,7 @@ func outputKernelSquashFS(image, base string, filesystem io.Reader) error {
 		if err != nil {
 			return err
 		}
+		thdr.Format = tar.FormatGNU
 		switch {
 		case thdr.Name == "boot/kernel":
 			kernel, err := ioutil.ReadAll(tr)


### PR DESCRIPTION
The default Go tar has restrictions on filename length for example.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>