### PR TITLE
Fix #218 enforce all outgoing tar files to use PAX

### DIFF
--- a/src/moby/image.go
+++ b/src/moby/image.go
@@ -178,6 +178,7 @@ func ImageTar(ref *reference.Spec, prefix string, tw tarWriter, trust bool, pull
 		} else {
 			log.Debugf("image tar: %s %s add %s", ref, prefix, hdr.Name)
 			hdr.Name = prefix + hdr.Name
+			hdr.Format = tar.FormatPAX
 			if hdr.Typeflag == tar.TypeLink {
 				// hard links are referenced by full path so need to be adjusted
 				hdr.Linkname = prefix + hdr.Linkname


### PR DESCRIPTION
While processing the content of a tar image, moby/tool was blindly
reusing the original tar format.
Moreover moby/tool locates the file under the prefix, so if the
original file was stored as USTAR, the filename length and new prefix
could be greater than the USTAR limit producing a fatal error.

The fix is to always enforce PAX format on all copied files from the
original image.

Signed-off-by: Brice Figureau <brice@daysofwonder.com>